### PR TITLE
Have StyleButton use map as a property

### DIFF
--- a/Examples/NavigationToolbarExample.qml
+++ b/Examples/NavigationToolbarExample.qml
@@ -40,6 +40,7 @@ Rectangle {
 
         NavigationToolbar {
             id: navigationToolbar
+            map: mainMap
             anchors {
                 top: parent.top
                 left: parent.left

--- a/Examples/StyleTemplateExample.qml
+++ b/Examples/StyleTemplateExample.qml
@@ -34,7 +34,7 @@ Rectangle {
     }
 
     Map {
-        id: map
+        id: mainMap
         anchors.fill: parent
         wrapAroundEnabled: true
         mapPanningByMagnifierEnabled: true
@@ -65,13 +65,14 @@ Rectangle {
             // Rotate Clockwise Button
             StyleButton {
                 id: buttonRotateClockwise
+                map: mainMap
                 iconSource: "images/rotate_clockwise.png"
                 width: internal._size
                 height: width
 
                 onClicked: {
                     fader.start();
-                    map.mapRotation -= 22.5;
+                    mainMap.mapRotation -= 22.5;
                 }
             }
 
@@ -79,13 +80,14 @@ Rectangle {
             // Rotate Counter Clockwise Button
             StyleButton {
                 id: buttonRotateCounterClockwise
+                map: mainMap
                 iconSource: "images/rotate_counter_clockwise.png"
                 width: internal._size
                 height: width
 
                 onClicked: {
                     fader.start();
-                    map.mapRotation += 22.5;
+                    mainMap.mapRotation += 22.5;
                 }
             }
 
@@ -93,6 +95,7 @@ Rectangle {
             // Info Button
             StyleButton {
                 id: infoButton
+                map: mainMap
                 iconSource: "images/info.png"
                 width: internal._size
                 height: width
@@ -108,6 +111,7 @@ Rectangle {
         // Pan North Button
         StyleButton {
             id: moveNorth
+            map: mainMap
             iconSource:"images/arrow.png"
             anchors {
                 top: parent.top
@@ -124,9 +128,9 @@ Rectangle {
             }
 
             onClicked: {
-                var extent = map.extent;
+                var extent = mainMap.extent;
                 extent.yMin += panDistance
-                map.panTo(extent)
+                mainMap.panTo(extent)
             }
         }
 
@@ -134,6 +138,7 @@ Rectangle {
         // Pan South Button
         StyleButton {
             id: moveSouth
+            map: mainMap
             iconSource:"images/arrow.png"
             rotation: 180
             anchors {
@@ -151,9 +156,9 @@ Rectangle {
             }
 
             onClicked: {
-                var extent = map.extent;
+                var extent = mainMap.extent;
                 extent.yMin -= panDistance;
-                map.panTo(extent)
+                mainMap.panTo(extent)
             }
         }
 
@@ -161,6 +166,7 @@ Rectangle {
         // Pan West Button
         StyleButton {
             id: moveWest
+            map: mainMap
             iconSource:"images/arrow.png"
             rotation: 270
             anchors {
@@ -178,9 +184,9 @@ Rectangle {
             }
 
             onClicked: {
-                var extent = map.extent;
+                var extent = mainMap.extent;
                 extent.xMin -= panDistance;
-                map.panTo(extent)
+                mainMap.panTo(extent)
             }
         }
 
@@ -188,6 +194,7 @@ Rectangle {
         // Pan East Button
         StyleButton {
             id: moveEast
+            map: mainMap
             iconSource:"images/arrow.png"
             rotation: 90
             anchors {
@@ -205,14 +212,15 @@ Rectangle {
             }
 
             onClicked: {
-                var extent = map.extent;
+                var extent = mainMap.extent;
                 extent.xMin += panDistance;
-                map.panTo(extent)
+                mainMap.panTo(extent)
             }
         }
 
         NavigationToolbar {
             id: navi
+            map: mainMap
             anchors {
                 top: parent.top
                 right: parent.right

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls.1.0/NavigationToolbar.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls.1.0/NavigationToolbar.qml
@@ -24,6 +24,7 @@ import ArcGIS.Runtime 10.26
 StyleToolbar {
     id: navigationToolbar
 
+    property Map map: null
     property real zoomRatio: 2
     property Envelope homeExtent
     readonly property int buttonZoomOut: 0x02
@@ -56,6 +57,7 @@ StyleToolbar {
     // Zoom-In Button
     ZoomInButton {
         id: zoomIn
+        map: navigationToolbar.map
 
         onHoveredChanged: {
             if (platform !== "android" && platform !== "ios") {
@@ -75,6 +77,7 @@ StyleToolbar {
     // Home Button
     HomeButton {
         id: home
+        map: navigationToolbar.map
 
         onHoveredChanged: {
             if (platform !== "android" && platform !== "ios") {
@@ -94,6 +97,7 @@ StyleToolbar {
     // Zoom-Out Button
     ZoomOutButton {
         id: zoomOut
+        map: navigationToolbar.map
 
         onHoveredChanged: {
             if (platform !== "android" && platform !== "ios") {
@@ -113,6 +117,7 @@ StyleToolbar {
     // PositionButton
     PositionButton {
         id: currentLocation
+        map: navigationToolbar.map
 
         onHoveredChanged: {
             if (platform !== "android" && platform !== "ios") {

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls.1.0/StyleButton.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls.1.0/StyleButton.qml
@@ -23,6 +23,7 @@ import ArcGIS.Runtime 10.26
 
 Button {
     id: styleButton
+    property Map map: null
     property real size: 40
     property color color: "#4C4C4C"
     property color disabledColor: "#E5E6E7"


### PR DESCRIPTION
Changing NavigationToolbarExample to use mainMap caused the buttons to lose the reference to the map. I propose changing StyleButton to take the map as a parameter (property) instead of relying on it being a specific id