### PR TITLE
James/adjust auto leader line

### DIFF
--- a/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
@@ -323,6 +323,9 @@ Item {
                 adjustRelativePositionOfCanvasFrame(anchorPointx, anchorPointy, rectWidth, rectHeight);
         }
 
+        if (leaderPosition !== Enums.LeaderPosition.Automatic)
+            adjustedLeaderPosition = leaderPosition
+
         // paint now.
         canvas.createPathAndPaint = true;
         canvas.requestPaint(true);

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
@@ -296,9 +296,9 @@ Item {
 
         // set the adjustedLeaderPosition
         if (leaderPosition !== Enums.LeaderPosition.Automatic)
-            adjustedLeaderPosition = leaderPosition
+            adjustedLeaderPosition = leaderPosition;
         else
-            adjustedLeaderPosition = Enums.LeaderPosition.Bottom
+            adjustedLeaderPosition = Enums.LeaderPosition.Bottom;
 
         // setup the accessory button mode
         setupAccessoryButton();
@@ -312,7 +312,7 @@ Item {
             adjustRelativePositionOfCanvasFrame(anchorPointx, anchorPointy, rectWidth, rectHeight);
 
         if (leaderPosition !== Enums.LeaderPosition.Automatic)
-            adjustedLeaderPosition = leaderPosition
+            adjustedLeaderPosition = leaderPosition;
 
         // create the callout frame don't paint yet.
         canvas.createPathAndPaint = false;

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
@@ -606,21 +606,19 @@ Item {
         if (leaderPosition === Enums.LeaderPosition.Automatic) {
 
             // Move leader vertically if vertical position isn't optimal
-            if (mousey + calloutFrame.height > root.parent.height && !refresh) {
-                // Bottom edge of callout is below bottom edge of map
-                refresh = moveLeader(Enums.LeaderMoveDirection.Down, mousex, mousey);
-            } else if (mousey - calloutFrame.height < 0 && !refresh) {
+            if (calloutFrame.y - edgeBuffer < 0) {
                 // Top edge of callout is above top edge of map
                 refresh = moveLeader(Enums.LeaderMoveDirection.Up, mousex, mousey);
             }
 
             // Move leader horizontally if horizontal position isn't optimal
-            if (mousex + calloutFrame.width > root.parent.width) {
-                // Right edge of callout is right of right edge of map
-                refresh = moveLeader(Enums.LeaderMoveDirection.Right, mousex, mousey);
-            } else if (mousex - calloutFrame.width < 0) {
+            if (calloutFrame.x - edgeBuffer < 0) {
                 // Left edge of callout is left of left edge of map
                 refresh = moveLeader(Enums.LeaderMoveDirection.Left, mousex, mousey);
+            } else if (calloutFrame.x + calloutFrame.width - (calloutFrame.width / 3) + edgeBuffer
+                       > root.parent.width) {
+                // Right edge of callout is right of right edge of map
+                refresh = moveLeader(Enums.LeaderMoveDirection.Right, mousex, mousey);
             }
 
         }

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
@@ -311,6 +311,9 @@ Item {
         else
             adjustRelativePositionOfCanvasFrame(anchorPointx, anchorPointy, rectWidth, rectHeight);
 
+        if (leaderPosition !== Enums.LeaderPosition.Automatic)
+            adjustedLeaderPosition = leaderPosition
+
         // create the callout frame don't paint yet.
         canvas.createPathAndPaint = false;
         canvas.requestPaint();
@@ -322,9 +325,6 @@ Item {
             else
                 adjustRelativePositionOfCanvasFrame(anchorPointx, anchorPointy, rectWidth, rectHeight);
         }
-
-        if (leaderPosition !== Enums.LeaderPosition.Automatic)
-            adjustedLeaderPosition = leaderPosition
 
         // paint now.
         canvas.createPathAndPaint = true;

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
@@ -297,6 +297,8 @@ Item {
         // set the adjustedLeaderPosition
         if (leaderPosition !== Enums.LeaderPosition.Automatic)
             adjustedLeaderPosition = leaderPosition
+        else
+            adjustedLeaderPosition = Enums.LeaderPosition.Bottom
 
         // setup the accessory button mode
         setupAccessoryButton();
@@ -308,9 +310,6 @@ Item {
             adjustRelativePositionOfCanvasFrame(anchorPointx, anchorPointy, calloutLayout.width - 2 * internalCornerRadius, calloutLayout.height - internalCornerRadius);
         else
             adjustRelativePositionOfCanvasFrame(anchorPointx, anchorPointy, rectWidth, rectHeight);
-
-        if (leaderPosition !== Enums.LeaderPosition.Automatic)
-            adjustedLeaderPosition = leaderPosition;
 
         // create the callout frame don't paint yet.
         canvas.createPathAndPaint = false;
@@ -603,6 +602,15 @@ Item {
 
         if (leaderPosition === Enums.LeaderPosition.Automatic) {
 
+            // Move leader vertically if vertical position isn't optimal
+            if (mousey + calloutFrame.height > root.parent.height && !refresh) {
+                // Bottom edge of callout is below bottom edge of map
+                refresh = moveLeader(Enums.LeaderMoveDirection.Down, mousex, mousey);
+            } else if (mousey - calloutFrame.height < 0 && !refresh) {
+                // Top edge of callout is above top edge of map
+                refresh = moveLeader(Enums.LeaderMoveDirection.Up, mousex, mousey);
+            }
+
             // Move leader horizontally if horizontal position isn't optimal
             if (mousex + calloutFrame.width > root.parent.width) {
                 // Right edge of callout is right of right edge of map
@@ -612,14 +620,6 @@ Item {
                 refresh = moveLeader(Enums.LeaderMoveDirection.Left, mousex, mousey);
             }
 
-            // Move leader vertically if vertical position isn't optimal
-            if (mousey + calloutFrame.height > root.parent.height && !refresh) {
-                // Bottom edge of callout is below bottom edge of map
-                refresh = moveLeader(Enums.LeaderMoveDirection.Down, mousex, mousey);
-            } else if (mousey - calloutFrame.height < 0 && !refresh) {
-                // Top edge of callout is above top edge of map
-                refresh = moveLeader(Enums.LeaderMoveDirection.Up, mousex, mousey);
-            }
         }
 
         return refresh;

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
@@ -615,8 +615,7 @@ Item {
             if (calloutFrame.x - edgeBuffer < 0) {
                 // Left edge of callout is left of left edge of map
                 refresh = moveLeader(Enums.LeaderMoveDirection.Left, mousex, mousey);
-            } else if (calloutFrame.x + calloutFrame.width - (calloutFrame.width / 3) + edgeBuffer
-                       > root.parent.width) {
+            } else if (calloutFrame.x + rectWidth + edgeBuffer > root.parent.width) {
                 // Right edge of callout is right of right edge of map
                 refresh = moveLeader(Enums.LeaderMoveDirection.Right, mousex, mousey);
             }


### PR DESCRIPTION
Assign to @nandinirao. Please review.

This is adjusting how the Automatic leader line setting works. Now it will always try to default to `Bottom` and adjust from there if it won't fit in the frame. I had to switch making the vertical and horizontal adjustments so it would work in the upper corners.

This is for v.next.

cc: @ldanzinger 