### PR TITLE
Nand6028/add max width

### DIFF
--- a/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
@@ -896,8 +896,6 @@ Item {
             console.log("imageWidth = ", imageWidth);
             console.log("maxWidth = ", maxWidth);
             console.log("calloutWidth = ", calloutWidth);
-            console.log("titleWidth = ", title.width);
-            console.log("detailWidth = ", detail.width);
             console.log("adjustedMaxWidth = ", adjustedMaxWidth);
             console.log("scaleFactor = ", scaleFactor);
         }

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
@@ -234,9 +234,9 @@ Item {
     /*! \internal */
     property real imageWidth: rectWidth / 4
     /*! \internal */
-    property real titleWidth: Math.max(0, rectWidth - 95)
+    property real titleWidth: Math.max(0, rectWidth - 95 * scaleFactor)
     /*! \internal */
-    property real detailWidth: Math.max(0, rectWidth - 95)
+    property real detailWidth: Math.max(0, rectWidth - 95 * scaleFactor)
     /*! \internal */
     property real cornerOffset: 15 * scaleFactor
     /*! \internal */
@@ -424,7 +424,7 @@ Item {
                         clip: true
                         elide: Text.ElideRight
                         Layout.alignment: Qt.AlignVCenter
-                        Layout.maximumWidth: !autoAdjustWidth ? titleWidth : Math.max(0, adjustedMaxWidth - 90) // resets to implicit width if non-autoAdjust
+                        Layout.maximumWidth: !autoAdjustWidth ? titleWidth : Math.max(0, adjustedMaxWidth - 90 * scaleFactor) // resets to implicit width if non-autoAdjust
                     }
 
                     Rectangle {
@@ -463,7 +463,7 @@ Item {
                         wrapMode: Text.NoWrap
                         elide: Text.ElideRight
                         Layout.alignment: Qt.AlignVCenter
-                        Layout.maximumWidth: !autoAdjustWidth ? detailWidth : Math.max(0, adjustedMaxWidth - 90) // resets to implicit width if non-autoAdjust
+                        Layout.maximumWidth: !autoAdjustWidth ? detailWidth : Math.max(0, adjustedMaxWidth - 90 * scaleFactor) // resets to implicit width if non-autoAdjust
                     }
                 }
             }
@@ -899,6 +899,7 @@ Item {
             console.log("titleWidth = ", title.width);
             console.log("detailWidth = ", detail.width);
             console.log("adjustedMaxWidth = ", adjustedMaxWidth);
+            console.log("scaleFactor = ", scaleFactor);
         }
     }
 

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
@@ -212,7 +212,7 @@ Item {
     /*! \internal */
     property real calloutMaxHeight: 45 * scaleFactor
     /*! \internal */
-    property real calloutMinWidth: 80 * scaleFactor
+    property real calloutMinWidth: 95 * scaleFactor
     /*! \internal */
     property real calloutMinHeight: calloutMaxHeight
     /*! \internal */

--- a/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls.2.0/Callout.qml
@@ -240,7 +240,7 @@ Item {
     /*! \internal */
     property real cornerOffset: 15 * scaleFactor
     /*! \internal */
-    property bool debug: true
+    property bool debug: false
     /*! \internal */
     property int internalCornerRadius: cornerRadius < 0 ? 0 : cornerRadius
     /*! \internal */


### PR DESCRIPTION
Assigned to @JamesMBallard 

FYI @ldanzinger 

 - Adding maxWidth for when autoAdjustWidth is set to true. The detail and title will be truncated if they can't fit in that width.
 - When autoAdjustWidth is false, width of callout can be set with calloutWidth. The detail and title will be truncated here too if it can't fit in that width.
 - Both these default to 300 per design.
 