### PR TITLE
There is an issue on Linux with using the ternary operator here. It's…

### DIFF
--- a/Imports/ArcGIS/Runtime/Toolkit/Controls/Callout.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls/Callout.qml
@@ -364,7 +364,12 @@ Item {
 
             // work around for Qt bug with Canvas on iOS.
             // Rendering to Frame buffer object causes weirdness with size.
-            renderTarget: (Qt.platform.os === "ios") ? Canvas.Image : Canvas.FramebufferObject
+            Component.onCompleted: {
+                if (Qt.platform.os === "ios")
+                    renderTarget = Canvas.Image;
+            }
+
+            renderTarget: Canvas.FramebufferObject
             renderStrategy: Canvas.Cooperative
 
             // handler to override for drawing


### PR DESCRIPTION
… unclear why but it causes a crash in some scenarios.

Assigned to @nandinirao. As discussed, we're seeing strange behavior on Linux with the ternary operator. It's unclear why it was crashing but it seemed to be crashing in qt internals.

Tested on all platforms for regressions by @ldanzinger.