### PR TITLE
Add support for import the toolkit components as a plugin.

### DIFF
--- a/Imports/ArcGIS/Runtime/Toolkit/Controls/Controls.qrc
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls/Controls.qrc
@@ -1,0 +1,46 @@
+<RCC>
+    <qresource prefix="/qt-project.org/imports/Esri/ArcGISRuntime/Toolkit/Controls">
+        <file>images/add-encircled.png</file>
+        <file>images/add.png</file>
+        <file>images/check-mark.png</file>
+        <file>images/delete.png</file>
+        <file>images/exit.png</file>
+        <file>images/home.png</file>
+        <file>images/info-encircled.png</file>
+        <file>images/info.png</file>
+        <file>images/NorthArrow.png</file>
+        <file>images/position-autopan.png</file>
+        <file>images/position-compass.png</file>
+        <file>images/position-navigation.png</file>
+        <file>images/position-off.png</file>
+        <file>images/position-on.png</file>
+        <file>images/remove.png</file>
+        <file>images/rotate_clockwise.png</file>
+        <file>images/rotate_counter_clockwise.png</file>
+        <file>images/search.png</file>
+        <file>images/triangle.png</file>
+        <file>LeaderPosition.js</file>
+        <file>AttachmentListView20.qml</file>
+        <file>AttributeListView20.qml</file>
+        <file>Callout.qml</file>
+        <file>Callout20.qml</file>
+        <file>Callout100.qml</file>
+        <file>CurrentVersion.qml</file>
+        <file>Fader20.qml</file>
+        <file>HomeButton20.qml</file>
+        <file>ImageButton20.qml</file>
+        <file>LocationButton20.qml</file>
+        <file>NavigationToolbar20.qml</file>
+        <file>NorthArrow20.qml</file>
+        <file>OverviewMap20.qml</file>
+        <file>PopupView.qml</file>
+        <file>PopupViewBase.qml</file>
+        <file>RotationToolbar20.qml</file>
+        <file>SearchBox20.qml</file>
+        <file>StyleButton20.qml</file>
+        <file>StyleToolbar20.qml</file>
+        <file>ZoomInButton20.qml</file>
+        <file>ZoomOutButton20.qml</file>
+        <file>qmldir</file>
+    </qresource>
+</RCC>

--- a/Imports/ArcGIS/Runtime/Toolkit/Dialogs/Dialogs.qrc
+++ b/Imports/ArcGIS/Runtime/Toolkit/Dialogs/Dialogs.qrc
@@ -1,0 +1,20 @@
+<RCC>
+    <qresource prefix="/qt-project.org/imports/Esri/ArcGISRuntime/Toolkit/Dialogs">
+        <file>images/add.png</file>
+        <file>images/banner.png</file>
+        <file>AuthenticationView.qml</file>
+        <file>AuthenticationView20.qml</file>
+        <file>ClientCertificateView.qml</file>
+        <file>ClientCertificateView20.qml</file>
+        <file>CurrentVersion.qml</file>
+        <file>ImagePopUpDialog20.qml</file>
+        <file>OAuth2View.qml</file>
+        <file>OAuth2View20.qml</file>
+        <file>SimpleDialog20.qml</file>
+        <file>SslHandshakeView.qml</file>
+        <file>SslHandshakeView20.qml</file>
+        <file>UserCredentialsView.qml</file>
+        <file>UserCredentialsView20.qml</file>
+        <file>qmldir</file>
+    </qresource>
+</RCC>

--- a/Plugin/ArcGISRuntimeToolkitPlugin.cpp
+++ b/Plugin/ArcGISRuntimeToolkitPlugin.cpp
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright 2012-2017 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ ******************************************************************************/
+
+#include "ArcGISRuntimeToolkitPlugin.h"
+
+ArcGISRuntimeToolkitPlugin::ArcGISRuntimeToolkitPlugin(QObject* parent) :
+  QQmlExtensionPlugin(parent)
+{
+  Q_INIT_RESOURCE(Controls);
+  Q_INIT_RESOURCE(Dialogs);
+}
+
+void ArcGISRuntimeToolkitPlugin::registerTypes(const char* uri)
+{
+  Q_UNUSED(uri)
+}

--- a/Plugin/ArcGISRuntimeToolkitPlugin.h
+++ b/Plugin/ArcGISRuntimeToolkitPlugin.h
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright 2012-2017 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ ******************************************************************************/
+
+#ifndef ArcGISRuntimeToolkitPlugin_H
+#define ArcGISRuntimeToolkitPlugin_H
+
+#include <QQmlExtensionPlugin>
+
+class ArcGISRuntimeToolkitPlugin : public QQmlExtensionPlugin
+{
+  Q_OBJECT
+  Q_PLUGIN_METADATA(IID QQmlExtensionInterface_iid)
+
+public:
+  explicit ArcGISRuntimeToolkitPlugin(QObject* parent = nullptr);
+  void registerTypes(const char* uri) Q_DECL_OVERRIDE;
+};
+
+#endif // ArcGISRuntimeToolkitPlugin_H

--- a/Plugin/ArcGISRuntimeToolkitPlugin.pri
+++ b/Plugin/ArcGISRuntimeToolkitPlugin.pri
@@ -14,21 +14,9 @@
 #   limitations under the License.
 ################################################################################
 
-mac {
-    cache()
-}
+HEADERS += $$PWD/ArcGISRuntimeToolkitPlugin.h
 
-#-------------------------------------------------------------------------------
+SOURCES += $$PWD/ArcGISRuntimeToolkitPlugin.cpp
 
-TEMPLATE = subdirs
-
-OTHER_FILES += \
-    README.md \
-    .gitattributes \
-    .gitignore \
-    Imports/*.qmlproject \
-    Examples/*.qmlproject \
-    Plugin/*
-
-#-------------------------------------------------------------------------------
-
+RESOURCES += $$PWD/../Imports/ArcGIS/Runtime/Toolkit/Controls/Controls.qrc \
+             $$PWD/../Imports/ArcGIS/Runtime/Toolkit/Dialogs/Dialogs.qrc


### PR DESCRIPTION
This will allow users to support Qt 5.9.x releases on iOS.

Assigned to @michael-tims 
cc: @ldanzinger 

This is a standalone solution for allowing users to import the toolkit components directly into their app. This is needed to support the toolkit on iOS with Qt 5.9.x