### PR TITLE
Refactor this logic a bit. Windows also needs unique output folders.

### DIFF
--- a/Plugin/CppApi/ArcGISRuntimeToolkit.pri
+++ b/Plugin/CppApi/ArcGISRuntimeToolkit.pri
@@ -39,4 +39,4 @@ win32: {
   }
 }
 
-QMAKE_LFLAGS += -L$$PWD/output/$$PLATFORM_OUTPUT -lArcGISRuntimeToolkitCppApi
+LIBS += -L$$PWD/output/$$PLATFORM_OUTPUT -lArcGISRuntimeToolkitCppApi

--- a/Plugin/CppApi/ArcGISRuntimeToolkit.pri
+++ b/Plugin/CppApi/ArcGISRuntimeToolkit.pri
@@ -29,10 +29,14 @@ android: {
 
 INCLUDEPATH += $PWD/include
 
-equals(ANDROID_ARCH, "") {
-  PLATFORM_OUTPUT = $$PLATFORM
-} else {
-  PLATFORM_OUTPUT = $$PLATFORM/$$ANDROID_ARCH
+!android:!win32: PLATFORM_OUTPUT = $$PLATFORM
+android: PLATFORM_OUTPUT = $$PLATFORM/$$ANDROID_ARCH
+win32: {
+  contains(QMAKE_TARGET.arch, x86_64): {
+    PLATFORM_OUTPUT = $$PLATFORM/x64
+  } else {
+    PLATFORM_OUTPUT = $$PLATFORM/x86
+  }
 }
 
 QMAKE_LFLAGS += -L$$PWD/output/$$PLATFORM_OUTPUT -lArcGISRuntimeToolkitCppApi

--- a/Plugin/CppApi/ArcGISRuntimeToolkit.pri
+++ b/Plugin/CppApi/ArcGISRuntimeToolkit.pri
@@ -27,7 +27,7 @@ android: {
   }
 }
 
-INCLUDEPATH += $PWD/include
+INCLUDEPATH += $$PWD/include
 
 !android:!win32: PLATFORM_OUTPUT = $$PLATFORM
 android: PLATFORM_OUTPUT = $$PLATFORM/$$ANDROID_ARCH

--- a/Plugin/CppApi/ArcGISRuntimeToolkit.pro
+++ b/Plugin/CppApi/ArcGISRuntimeToolkit.pro
@@ -55,10 +55,14 @@ else {
   BUILDTYPE = debug
 }
 
-equals(ANDROID_ARCH, "") {
-  PLATFORM_OUTPUT = $$PLATFORM
-} else {
-  PLATFORM_OUTPUT = $$PLATFORM/$$ANDROID_ARCH
+!android:!win32: PLATFORM_OUTPUT = $$PLATFORM
+android: PLATFORM_OUTPUT = $$PLATFORM/$$ANDROID_ARCH
+win32: {
+  contains(QMAKE_TARGET.arch, x86_64): {
+    PLATFORM_OUTPUT = $$PLATFORM/x64
+  } else {
+    PLATFORM_OUTPUT = $$PLATFORM/x86
+  }
 }
 
 DESTDIR = $$PWD/output/$$PLATFORM_OUTPUT


### PR DESCRIPTION
Assigned to @khajra 

One more small change to support building 32 and 64-bit on the same Windows machine. Without this the build output will clobber each other.

I retested all platforms and only the Windows output folder is changed.