### PR TITLE
- make AbstractTool a QObject as we will need signals on the base

### DIFF
--- a/Plugin/CppApi/include/AbstractTool.h
+++ b/Plugin/CppApi/include/AbstractTool.h
@@ -14,6 +14,8 @@
 #define ABSTRACT_TOOL_H
 
 #include "ToolkitCommon.h"
+
+#include <QObject>
 #include <QString>
 
 namespace Esri
@@ -21,15 +23,18 @@ namespace Esri
 namespace ArcGISRuntime
 {
 
+class Basemap;
 class Point;
 
 namespace Toolkit
 {
 
-class TOOLKIT_EXPORT AbstractTool
+class TOOLKIT_EXPORT AbstractTool : public QObject
 {
+  Q_OBJECT
+
 public:
-  AbstractTool();
+  AbstractTool(QObject* parent = nullptr);
   virtual ~AbstractTool();
 
   virtual QString toolName() const = 0;
@@ -37,6 +42,9 @@ public:
 
   virtual void setActive(bool active);
   bool isActive() const;
+
+signals:
+  void basemapChanged(Basemap* basemap);
 
 protected:
   bool m_active = false;

--- a/Plugin/CppApi/include/CoordinateConversionController.h
+++ b/Plugin/CppApi/include/CoordinateConversionController.h
@@ -32,7 +32,7 @@ namespace Toolkit
 
 class CoordinateConversionResults;
 
-class TOOLKIT_EXPORT CoordinateConversionController : public QObject, public AbstractTool
+class TOOLKIT_EXPORT CoordinateConversionController : public AbstractTool
 {
   Q_OBJECT
 

--- a/Plugin/CppApi/source/AbstractTool.cpp
+++ b/Plugin/CppApi/source/AbstractTool.cpp
@@ -19,7 +19,8 @@ namespace ArcGISRuntime
 namespace Toolkit
 {
 
-AbstractTool::AbstractTool()
+AbstractTool::AbstractTool(QObject* parent /*= nullptr */):
+  QObject(parent)
 {
 }
 

--- a/Plugin/CppApi/source/CoordinateConversionController.cpp
+++ b/Plugin/CppApi/source/CoordinateConversionController.cpp
@@ -26,7 +26,7 @@ namespace Toolkit
 using CoordinateType = CoordinateConversionOptions::CoordinateType;
 
 CoordinateConversionController::CoordinateConversionController(QObject* parent):
-  QObject(parent)
+  AbstractTool(parent)
 {
   connect(this, &CoordinateConversionController::optionsChanged, this,
   [this]()


### PR DESCRIPTION
- add basemapChanged signal (required for BasemapPicker)

@JamesMBallard - please review the changes to the `AbstractTool` interface