### PR TITLE
For Esri builds, include the versioning and copyright information.

### DIFF
--- a/Plugin/CppApi/ArcGISRuntimeToolkit.rc
+++ b/Plugin/CppApi/ArcGISRuntimeToolkit.rc
@@ -1,0 +1,43 @@
+#include "..\..\..\..\..\buildnum\buildnum.h"
+#include <winver.h>
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// Version
+//
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION BUILD_VER
+ PRODUCTVERSION BUILD_VER
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS 0x4L
+ FILETYPE 0x2L
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"
+        BEGIN
+            VALUE "Comments","ArcGIS Runtime SDK for Qt Cpp Api Toolkit library"
+            VALUE "CompanyName", COMPANY_NAME
+            VALUE "FileDescription", "ArcGIS Runtime SDK for Qt Cpp Api Toolkit library\0"
+            VALUE "FileVersion", BUILD_NUM
+            VALUE "InternalName", "ArcGISRuntimeToolkitCppApi\0"
+            VALUE "LegalCopyright", COPY_RIGHT
+            VALUE "LegalTrademarks", "\0"
+            VALUE "OriginalFilename", "ArcGISRuntimeToolkitCppApi.dll\0"
+            VALUE "ProductName", PRODUCT_NAME
+            VALUE "ProductVersion", BUILD_NUM
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/Plugin/CppApi/dev_build_config.pri
+++ b/Plugin/CppApi/dev_build_config.pri
@@ -28,6 +28,8 @@ android: {
   }
 }
 
+win32:RC_FILE += $$PWD/ArcGISRuntimeToolkit.rc
+
 INCLUDEPATH += ../../../../api/qt_cpp/Include
 
 !ios:LIBS += -L$${DESTDIR} -L$${LIB_FOLDER_STATICLIB} \


### PR DESCRIPTION
Assign to @michael-tims. Please review.

For Esri's daily builds, the dll should contain versioning and copyright information. Any local builds (by users, for example) will not embed any of this information in the dll.

