### PR TITLE
ArcGISCompass Inherits from AbstractTool

### DIFF
--- a/Imports/ArcGIS/Runtime/Toolkit/Controls/CppApi/ArcGISCompass.qml
+++ b/Imports/ArcGIS/Runtime/Toolkit/Controls/CppApi/ArcGISCompass.qml
@@ -2,6 +2,7 @@ import QtQuick 2.6
 import QtQuick.Controls 1.4
 import QtQuick.Controls.Styles 1.4
 import Esri.ArcGISExtras 1.1
+import Esri.ArcGISRuntime.Toolkit.CppApi 100.2
 
 Item {
     property real scaleFactor: System.displayScaleFactor

--- a/Plugin/CppApi/include/ArcGISCompassController.h
+++ b/Plugin/CppApi/include/ArcGISCompassController.h
@@ -16,6 +16,7 @@
 #include <QObject>
 
 #include "ToolkitCommon.h"
+#include "AbstractTool.h"
 
 namespace Esri
 {
@@ -27,7 +28,7 @@ class SceneQuickView;
 
 namespace Toolkit
 {
-class TOOLKIT_EXPORT ArcGISCompassController : public QObject
+class TOOLKIT_EXPORT ArcGISCompassController : public QObject, public AbstractTool
 {
   Q_OBJECT
 
@@ -54,6 +55,8 @@ public:
 
   double heading() const;
   bool autoHide() const;
+
+  QString toolName() const override;
 
 private:
   double m_heading = 0.0;

--- a/Plugin/CppApi/source/ArcGISCompassController.cpp
+++ b/Plugin/CppApi/source/ArcGISCompassController.cpp
@@ -113,12 +113,12 @@ double ArcGISCompassController::heading() const
 
 bool ArcGISCompassController::autoHide() const
 {
-    return m_autoHide;
+  return m_autoHide;
 }
 
 QString ArcGISCompassController::toolName() const
 {
-    return "ArcGISCompass";
+  return "ArcGISCompass";
 }
 
 } // Toolkit

--- a/Plugin/CppApi/source/ArcGISCompassController.cpp
+++ b/Plugin/CppApi/source/ArcGISCompassController.cpp
@@ -113,7 +113,12 @@ double ArcGISCompassController::heading() const
 
 bool ArcGISCompassController::autoHide() const
 {
-  return m_autoHide;
+    return m_autoHide;
+}
+
+QString ArcGISCompassController::toolName() const
+{
+    return "ArcGISCompass";
 }
 
 } // Toolkit


### PR DESCRIPTION
Made `ArcGISCompass` inherit from AbstractTool and added the appropriate import statement to QML view.

@JamesMBallard Please review and merge. Thank you.