### PR TITLE
Compass SetView Function

### DIFF
--- a/Plugin/CppApi/include/ArcGISCompassController.h
+++ b/Plugin/CppApi/include/ArcGISCompassController.h
@@ -25,6 +25,7 @@ namespace ArcGISRuntime
 
 class MapQuickView;
 class SceneQuickView;
+class GeoView;
 
 namespace Toolkit
 {
@@ -50,6 +51,7 @@ public:
   ArcGISCompassController(QObject *parent = nullptr);
   ~ArcGISCompassController();
 
+  bool setView(Esri::ArcGISRuntime::GeoView* geoView);
   bool setView(Esri::ArcGISRuntime::MapQuickView* mapView);
   bool setView(Esri::ArcGISRuntime::SceneQuickView* sceneView);
 

--- a/Plugin/CppApi/source/ArcGISCompassController.cpp
+++ b/Plugin/CppApi/source/ArcGISCompassController.cpp
@@ -58,6 +58,23 @@ void ArcGISCompassController::setAutoHide(bool autoHide)
   emit autoHideChanged();
 }
 
+bool ArcGISCompassController::setView(GeoView *geoView)
+{
+  if (!geoView)
+    return false;
+
+  // controller can only be set to one view
+  if (m_sceneView != nullptr || m_mapView != nullptr)
+    return false;
+
+  if (geoView->geoViewType() == GeoViewType::SceneView)
+    return setView(static_cast<SceneQuickView*>(geoView));
+  else if(geoView->geoViewType() == GeoViewType::MapView)
+    return setView(static_cast<MapQuickView*>(geoView));
+  else
+    return false;
+}
+
 bool ArcGISCompassController::setView(MapQuickView* mapView)
 {
   if (!mapView)


### PR DESCRIPTION
Added overloaded function `setView(GeoView*)` that performs casts to appropriate type of GeoView.

@michael-tims Please review and merge. Thank you.