### PR TITLE
Add coordinate and compass to the tool manager

### DIFF
--- a/Plugin/CppApi/include/AbstractTool.h
+++ b/Plugin/CppApi/include/AbstractTool.h
@@ -14,6 +14,8 @@
 #define ABSTRACT_TOOL_H
 
 #include "ToolkitCommon.h"
+
+#include <QObject>
 #include <QString>
 
 namespace Esri
@@ -26,10 +28,11 @@ class Point;
 namespace Toolkit
 {
 
-class TOOLKIT_EXPORT AbstractTool
+class TOOLKIT_EXPORT AbstractTool : public QObject
 {
+  Q_OBJECT
 public:
-  AbstractTool();
+  AbstractTool(QObject* parent = nullptr);
   virtual ~AbstractTool();
 
   virtual QString toolName() const = 0;

--- a/Plugin/CppApi/include/ArcGISCompassController.h
+++ b/Plugin/CppApi/include/ArcGISCompassController.h
@@ -13,9 +13,6 @@
 #ifndef ARCGISCOMPASSCONTROLLER_H
 #define ARCGISCOMPASSCONTROLLER_H
 
-#include <QObject>
-
-#include "ToolkitCommon.h"
 #include "AbstractTool.h"
 
 namespace Esri
@@ -29,7 +26,7 @@ class GeoView;
 
 namespace Toolkit
 {
-class TOOLKIT_EXPORT ArcGISCompassController : public QObject, public AbstractTool
+class TOOLKIT_EXPORT ArcGISCompassController : public AbstractTool
 {
   Q_OBJECT
 

--- a/Plugin/CppApi/include/CoordinateConversionController.h
+++ b/Plugin/CppApi/include/CoordinateConversionController.h
@@ -13,7 +13,6 @@
 #ifndef COORDINATECONVERSIONCONTROLLER_H
 #define COORDINATECONVERSIONCONTROLLER_H
 
-#include <QObject>
 #include <QQmlListProperty>
 
 #include "AbstractTool.h"
@@ -32,7 +31,7 @@ namespace Toolkit
 
 class CoordinateConversionResults;
 
-class TOOLKIT_EXPORT CoordinateConversionController : public QObject, public AbstractTool
+class TOOLKIT_EXPORT CoordinateConversionController : public AbstractTool
 {
   Q_OBJECT
 

--- a/Plugin/CppApi/source/AbstractTool.cpp
+++ b/Plugin/CppApi/source/AbstractTool.cpp
@@ -19,8 +19,10 @@ namespace ArcGISRuntime
 namespace Toolkit
 {
 
-AbstractTool::AbstractTool()
+AbstractTool::AbstractTool(QObject* parent /*= nullptr*/):
+  QObject(parent)
 {
+
 }
 
 AbstractTool::~AbstractTool()

--- a/Plugin/CppApi/source/ArcGISCompassController.cpp
+++ b/Plugin/CppApi/source/ArcGISCompassController.cpp
@@ -13,7 +13,9 @@
 #include "Camera.h"
 #include "MapQuickView.h"
 #include "SceneQuickView.h"
+
 #include "ArcGISCompassController.h"
+#include "ToolManager.h"
 
 using namespace Esri::ArcGISRuntime;
 
@@ -25,8 +27,9 @@ namespace Toolkit
 {
 
 ArcGISCompassController::ArcGISCompassController(QObject *parent):
-  QObject(parent)
+  AbstractTool(parent)
 {
+  ToolManager::instance()->addTool(this);
 }
 
 ArcGISCompassController::~ArcGISCompassController()

--- a/Plugin/CppApi/source/CoordinateConversionController.cpp
+++ b/Plugin/CppApi/source/CoordinateConversionController.cpp
@@ -16,6 +16,8 @@
 #include <QClipboard>
 #include <QApplication>
 
+#include "ToolManager.h"
+
 namespace Esri
 {
 namespace ArcGISRuntime
@@ -26,8 +28,10 @@ namespace Toolkit
 using CoordinateType = CoordinateConversionOptions::CoordinateType;
 
 CoordinateConversionController::CoordinateConversionController(QObject* parent):
-  QObject(parent)
+  AbstractTool(parent)
 {
+  ToolManager::instance()->addTool(this);
+
   connect(this, &CoordinateConversionController::optionsChanged, this,
   [this]()
   {


### PR DESCRIPTION
@michael-tims please review the changes to the toolkit to make AbstractTool a QObject and to register existing tools with the ToolManager