### PR TITLE
Fix Linux build problem.

### DIFF
--- a/Plugin/CppApi/ArcGISRuntimeToolkit.pro
+++ b/Plugin/CppApi/ArcGISRuntimeToolkit.pro
@@ -37,6 +37,12 @@ ARCGIS_RUNTIME_VERSION = 100.2
   include($$PWD/dev_build_config.pri)
 }
 
+unix:!macx:!android:!ios: {
+  # Linux: make sure we get the definition of std::__throw_bad_function_call from the
+  # standard library since libQt5Qml.so.5.6.2 also defines it.
+  LIBS += -lstdc++
+}
+
 ios {
   RESOURCES += $${PWD}/ArcGISRuntimeToolkit.qrc
   # the following file is needed to generate universal iOS libs


### PR DESCRIPTION
If you consume this library with Qt 5.9.1 you get linker errors.
That's because libQt5Qml.so from 5.6.2 defines this symbol and
newer versions don't (5.9.1 does not). We need to make sure we're
getting the definition from the C++ standard library rather than Qt.

Assigned to @michael-tims. Please review.