### PR TITLE
Enable bitcode for local builds.

### DIFF
--- a/Plugin/CppApi/ArcGISRuntimeToolkit.pro
+++ b/Plugin/CppApi/ArcGISRuntimeToolkit.pro
@@ -44,6 +44,7 @@ unix:!macx:!android:!ios: {
 }
 
 ios {
+  QMAKE_CXXFLAGS += -fembed-bitcode
   RESOURCES += $${PWD}/ArcGISRuntimeToolkit.qrc
   # the following file is needed to generate universal iOS libs
   # prior to Qt 5.8


### PR DESCRIPTION
This is already enabled for development builds.

This is to aid local development.