### PR TITLE
Move view-specific connection logic out of the toolkit and into the a…

### DIFF
--- a/Plugin/CppApi/include/ToolResourceProvider.h
+++ b/Plugin/CppApi/include/ToolResourceProvider.h
@@ -70,14 +70,9 @@ signals:
 private:
   explicit ToolResourceProvider(QObject* parent = nullptr);
 
-  void setupGeoViewConnections();
-
   GeoView* m_geoView = nullptr;
   Map* m_map = nullptr;
   Scene* m_scene = nullptr;
-
-  QMetaObject::Connection m_srChangedConn;
-  QMetaObject::Connection m_pointClickedConn;
 };
 
 } // Toolkit

--- a/Plugin/CppApi/include/ToolResourceProvider.h
+++ b/Plugin/CppApi/include/ToolResourceProvider.h
@@ -17,6 +17,7 @@
 
 #include "ToolkitCommon.h"
 #include "Point.h"
+#include <QMouseEvent>
 
 namespace Esri
 {
@@ -60,12 +61,16 @@ public:
 
   void clear();
 
+public slots:
+  void onMouseClicked(QMouseEvent& mouseEvent);
+
 signals:
   void sceneChanged();
   void geoViewChanged();
   void mapChanged();
   void spatialReferenceChanged();
-  void mouseClicked(const Point& point);
+  void mouseClicked(QMouseEvent& mouseEvent);
+  void mouseClickedPoint(const Point& point);
 
 private:
   explicit ToolResourceProvider(QObject* parent = nullptr);

--- a/Plugin/CppApi/source/CoordinateConversionController.cpp
+++ b/Plugin/CppApi/source/CoordinateConversionController.cpp
@@ -59,7 +59,7 @@ CoordinateConversionController::CoordinateConversionController(QObject* parent):
     setSpatialReference(ToolResourceProvider::instance()->spatialReference());
   });
 
-  connect(ToolResourceProvider::instance(), &ToolResourceProvider::mouseClicked, this,
+  connect(ToolResourceProvider::instance(), &ToolResourceProvider::mouseClickedPoint, this,
   [this](const Point& point)
   {
     setPointToConvert(point);

--- a/Plugin/CppApi/source/ToolResourceProvider.cpp
+++ b/Plugin/CppApi/source/ToolResourceProvider.cpp
@@ -14,8 +14,6 @@
 #include "Map.h"
 #include "Scene.h"
 #include "GeoView.h"
-#include "MapQuickView.h"
-#include "SceneQuickView.h"
 
 #include "ToolResourceProvider.h"
 
@@ -89,8 +87,6 @@ void ToolResourceProvider::setGeoView(GeoView* newGeoView)
 
   if (!m_geoView->spatialReference().isEmpty())
     emit spatialReferenceChanged();
-
-  setupGeoViewConnections();
 }
 
 SpatialReference ToolResourceProvider::spatialReference() const
@@ -122,40 +118,6 @@ void ToolResourceProvider::setBasemap(Basemap* newBasemap)
   {
     newBasemap->setParent(m_scene);
     m_scene->setBasemap(newBasemap);
-  }
-}
-
-void ToolResourceProvider::setupGeoViewConnections()
-{
-  if (m_srChangedConn)
-    disconnect(m_srChangedConn);
-
-  if (m_pointClickedConn)
-    disconnect(m_pointClickedConn);
-
-  if (dynamic_cast<SceneQuickView*>(m_geoView))
-  {
-    auto sceneView = static_cast<SceneQuickView*>(m_geoView);
-    m_srChangedConn = connect(sceneView, &SceneQuickView::spatialReferenceChanged,
-                              this, &ToolResourceProvider::spatialReferenceChanged);
-
-    m_pointClickedConn = connect(sceneView, &SceneQuickView::mouseClicked, this,
-    [this, sceneView](QMouseEvent& event)
-    {
-      emit mouseClicked(sceneView->screenToBaseSurface(event.x(), event.y()));
-    });
-  }
-  else if (dynamic_cast<MapQuickView*>(m_geoView))
-  {
-    auto mapView = static_cast<MapQuickView*>(m_geoView);
-    m_srChangedConn = connect(mapView, &MapQuickView::spatialReferenceChanged,
-                              this, &ToolResourceProvider::spatialReferenceChanged);
-
-    m_pointClickedConn = connect(mapView, &MapQuickView::mouseClicked, this,
-    [this, mapView](QMouseEvent& event)
-    {
-      emit mouseClicked(mapView->screenToLocation(event.x(), event.y()));
-    });
   }
 }
 

--- a/Plugin/CppApi/source/ToolResourceProvider.cpp
+++ b/Plugin/CppApi/source/ToolResourceProvider.cpp
@@ -14,6 +14,8 @@
 #include "Map.h"
 #include "Scene.h"
 #include "GeoView.h"
+#include "MapView.h"
+#include "SceneView.h"
 
 #include "ToolResourceProvider.h"
 
@@ -119,6 +121,23 @@ void ToolResourceProvider::setBasemap(Basemap* newBasemap)
     newBasemap->setParent(m_scene);
     m_scene->setBasemap(newBasemap);
   }
+}
+
+void ToolResourceProvider::onMouseClicked(QMouseEvent& mouseEvent)
+{
+  emit mouseClicked(mouseEvent);
+
+  if (!m_geoView)
+    return;
+
+  if (m_scene)
+    emit mouseClickedPoint(static_cast<SceneView*>(m_geoView)->screenToBaseSurface(mouseEvent.x(), mouseEvent.y()));
+  else if (m_map)
+    emit mouseClickedPoint(static_cast<MapView*>(m_geoView)->screenToLocation(mouseEvent.x(), mouseEvent.y()));
+  else if (dynamic_cast<SceneView*>(m_geoView))
+    emit mouseClickedPoint(static_cast<SceneView*>(m_geoView)->screenToBaseSurface(mouseEvent.x(), mouseEvent.y()));
+  else if (dynamic_cast<MapView*>(m_geoView))
+    emit mouseClickedPoint(static_cast<MapView*>(m_geoView)->screenToLocation(mouseEvent.x(), mouseEvent.y()));
 }
 
 void ToolResourceProvider::clear()


### PR DESCRIPTION
…pps.

Assigned to @michael-tims 

Remove the view-specific logic from the toolkit so it doesn't need to depend on Quick or Widgets directly.

cc: @lsmallwood 