### PR TITLE
Add debug build suffixes to the link line for Windows and Mac.

### DIFF
--- a/Plugin/CppApi/ArcGISRuntimeToolkit.pri
+++ b/Plugin/CppApi/ArcGISRuntimeToolkit.pri
@@ -16,6 +16,11 @@
 
 CONFIG(ToolkitBuildUsePrefix): ToolkitPrefix = _dev
 
+CONFIG(debug, debug|release) {
+  macx:  DebugSuffix = _debug
+  win32: DebugSuffix = d
+}
+
 macx: PLATFORM = "macOS"
 unix:!macx:!android:!ios: PLATFORM = "linux"
 win32: PLATFORM = "windows"
@@ -41,7 +46,7 @@ win32: {
   }
 }
 
-LIBS += -L$$PWD/output/$$PLATFORM_OUTPUT -lArcGISRuntimeToolkitCppApi$${ToolkitPrefix}
+LIBS += -L$$PWD/output/$$PLATFORM_OUTPUT -lArcGISRuntimeToolkitCppApi$${ToolkitPrefix}$${DebugSuffix}
 
 # unset the previous toolkit path
 DEFINES -= ARCGIS_TOOLKIT_IMPORT_PATH=\"$$ARCGIS_TOOLKIT_IMPORT_PATH\"


### PR DESCRIPTION
Assigned to @khajra. 

Fix linking problems with local debug builds for Mac and Windows.