### PR TITLE
macOS deployment ver stored in shared pri

### DIFF
--- a/Plugin/CppApi/ArcGISRuntimeToolkit.pro
+++ b/Plugin/CppApi/ArcGISRuntimeToolkit.pro
@@ -59,7 +59,6 @@ ios {
 }
 
 macx: {
-  QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.11
   QMAKE_POST_LINK =
 }
 


### PR DESCRIPTION
Assign to @JamesMBallard 

`QMAKE_MACOSX_DEPLOYMENT_TARGET` is now located in the shared pri files.  Not needed in all pro files anymore.