### PR TITLE
James/v.next/popup view close

### DIFF
--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupStackView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupStackView.qml
@@ -166,6 +166,13 @@ Item {
     property int currentIndex: 0
 
     /*!
+        \brief The color used for the close button.
+
+        The default color is \c "gray".
+    */
+    property color closeButtonColor: "gray"
+
+    /*!
         \brief The visibility of the PopupStackView.
 
         The default visibility is \c false.
@@ -358,9 +365,11 @@ Item {
         attributeNameTextColorInternal: attributeNameTextColor
         attributeValueTextColorInternal: attributeValueTextColor
         titleTextColorInternal: titleTextColor
+        closeButtonColorInternal: closeButtonColor
         visible: false
 
         onAttachmentThumbnailClickedInternal: attachmentThumbnailClicked(index)
+        onPopupViewDismissed: dismiss();
     }
 
     /*! internal */
@@ -374,9 +383,11 @@ Item {
         attributeNameTextColorInternal: attributeNameTextColor
         attributeValueTextColorInternal: attributeValueTextColor
         titleTextColorInternal: titleTextColor
+        closeButtonColorInternal: closeButtonColor
         visible: false
 
         onAttachmentThumbnailClickedInternal: attachmentThumbnailClicked(index)
+        onPopupViewDismissed: dismiss();
     }
 
     Column {

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupView.qml
@@ -155,6 +155,13 @@ Item {
     property real animationEasingType: Easing.OutQuad
 
     /*!
+        \brief The color used for the close button.
+
+        The default color is \c "gray".
+    */
+    property color closeButtonColor: "gray"
+
+    /*!
         \brief The visibility of the PopupView.
 
         The default visibility is \c false.
@@ -279,7 +286,9 @@ Item {
         attributeNameTextColorInternal: attributeNameTextColor
         attributeValueTextColorInternal: attributeValueTextColor
         titleTextColorInternal: titleTextColor
+        closeButtonColorInternal: closeButtonColor
 
         onAttachmentThumbnailClickedInternal: attachmentThumbnailClicked(index)
+        onPopupViewDismissed: dismiss();
     }
 }

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupViewBase.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupViewBase.qml
@@ -250,4 +250,8 @@ Item {
             }
         }
     }
+
+    onCloseButtonColorInternalChanged: {
+        closeButtonCanvas.requestPaint();
+    }
 }

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupViewBase.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupViewBase.qml
@@ -32,12 +32,14 @@ Item {
     property color titleTextColorInternal
     property color attributeNameTextColorInternal
     property color attributeValueTextColorInternal
+    property color closeButtonColorInternal
     property var popupManagerInternal: null
     property real displayScaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" ? 96 : 72)
     property var displayedFields: null
     property var attachments: null
     property bool showAttachments: false
     signal attachmentThumbnailClickedInternal(var index)
+    signal popupViewDismissed()
     
     onPopupManagerInternalChanged: {
         if (popupManagerInternal) {
@@ -46,6 +48,33 @@ Item {
             showAttachments = popupManagerInternal.showAttachments;
             titleTextInternal = popupManagerInternal.title;
         }
+    }
+
+    /*! internal */
+    function drawCloseButton(canvas) {
+        var ctx = canvas.getContext("2d");
+        ctx.strokeStyle = closeButtonColorInternal;
+        ctx.lineWidth = canvas.height / 10;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.save();
+
+        var canvasWidth = canvas.width;
+        var canvasHeight = canvas.height;
+
+        // place at origin
+        ctx.translate(0, 0);
+        ctx.beginPath();
+
+        // line 1
+        ctx.moveTo(canvasWidth, canvasHeight);
+        ctx.lineTo(0, 0);
+
+        // line 2
+        ctx.moveTo(canvasWidth, 0);
+        ctx.lineTo(0, canvasHeight);
+
+        ctx.stroke();
+        ctx.restore();
     }
 
     Rectangle {
@@ -75,22 +104,49 @@ Item {
             spacing: 10 * displayScaleFactor
             clip: true
 
-            Text {
-                width: parent.width
-                text: titleTextInternal
-                elide: Text.ElideRight
-                color: titleTextColorInternal
-                font {
-                    family: "serif"
-                    pixelSize: titleTextSizeInternal
-                    bold: true
+            Row {
+                Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: heading.width * 0.9
+                    text: titleTextInternal
+                    elide: Text.ElideRight
+                    color: titleTextColorInternal
+                    font {
+                        family: "serif"
+                        pixelSize: titleTextSizeInternal
+                        bold: true
+                    }
+                    renderType: Text.NativeRendering
                 }
-                renderType: Text.NativeRendering
+
+                Canvas {
+                    id: closeButtonCanvas
+                    anchors.verticalCenter: parent.verticalCenter
+                    antialiasing: true
+                    height: parent.height
+                    width: height
+
+                    onPaint: {
+                        drawCloseButton(closeButtonCanvas);
+                    }
+
+                    Component.onCompleted: {
+                        if (Qt.platform.os === "ios")
+                            renderTarget = Canvas.Image;
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        onClicked: {
+                            popupViewDismissed();
+                        }
+                    }
+                }
             }
 
             Rectangle {
                 width: parent.width
-                height: 1 * displayScaleFactor
+                height: displayScaleFactor
                 color: borderColorInternal
             }
         }


### PR DESCRIPTION
Assign to @ldanzinger. Please review.

New close button for the PopupView(s). Just like the popup stack view, we draw the button so the user can customize the color. I've tested on Mac, Windows and iOS simulator and it looks consistent on all of them.

This is for v.next. I'll have a follow-up PR for release/100.2.1 after this is in.