### PR TITLE
Add API ref and remove tools when they are destroyed

### DIFF
--- a/Plugin/CppApi/include/ToolManager.h
+++ b/Plugin/CppApi/include/ToolManager.h
@@ -42,6 +42,8 @@ public:
 
   void removeTool(const QString& toolName);
 
+  void removeTool(AbstractTool* tool);
+
   void clearTools();
 
   AbstractTool* tool(const QString& toolName) const;

--- a/Plugin/CppApi/include/ToolManager.h
+++ b/Plugin/CppApi/include/ToolManager.h
@@ -40,6 +40,10 @@ public:
 
   void addTool(AbstractTool* tool);
 
+  void removeTool(const QString& toolName);
+
+  void clearTools();
+
   AbstractTool* tool(const QString& toolName) const;
 
   template<class T>

--- a/Plugin/CppApi/source/ToolManager.cpp
+++ b/Plugin/CppApi/source/ToolManager.cpp
@@ -60,16 +60,7 @@ void ToolManager::addTool(AbstractTool* tool)
   // when a tool is destroyed, remove it from the manager
   QObject::connect(tool, &AbstractTool::destroyed, tool, [this, tool]()
   {
-    auto it = m_tools.begin();
-    auto itEnd = m_tools.end();
-    for(; it != itEnd; ++it)
-    {
-      if (it.value() == tool)
-      {
-        m_tools.erase(it);
-        break;
-      }
-    }
+    removeTool(tool);
   });
 
   m_tools.insert(tool->toolName(), tool);
@@ -80,6 +71,25 @@ void ToolManager::addTool(AbstractTool* tool)
 void ToolManager::removeTool(const QString& toolName)
 {
   m_tools.remove(toolName);
+}
+
+/*! \brief Removes the \l AbstractTool \a tool from the manager.
+ */
+void ToolManager::removeTool(AbstractTool* tool)
+{
+  if (tool == nullptr)
+    return;
+
+  auto it = m_tools.begin();
+  auto itEnd = m_tools.end();
+  for(; it != itEnd; ++it)
+  {
+    if (it.value() == tool)
+    {
+      m_tools.erase(it);
+      return;
+    }
+  }
 }
 
 /*! \brief Clears all tools from the manager.

--- a/Plugin/CppApi/source/ToolManager.cpp
+++ b/Plugin/CppApi/source/ToolManager.cpp
@@ -75,6 +75,20 @@ void ToolManager::addTool(AbstractTool* tool)
   m_tools.insert(tool->toolName(), tool);
 }
 
+/*! \brief Removes the \l AbstractTool called \a toolName from the manager.
+ */
+void ToolManager::removeTool(const QString& toolName)
+{
+  m_tools.remove(toolName);
+}
+
+/*! \brief Clears all tools from the manager.
+ */
+void ToolManager::clearTools()
+{
+  m_tools.clear();
+}
+
 /*! \brief Retrieve the \l AbsgtractTool with the name \a toolName.
  *
  * return \c nullptr if the tool cannot be found.

--- a/Plugin/CppApi/source/ToolManager.cpp
+++ b/Plugin/CppApi/source/ToolManager.cpp
@@ -21,6 +21,9 @@ namespace ArcGISRuntime
 namespace Toolkit
 {
 
+/*! \brief Returns the singleton instance of the tool manager.
+ *
+ */
 ToolManager& ToolManager::instance()
 {
   static ToolManager instance;
@@ -28,44 +31,86 @@ ToolManager& ToolManager::instance()
   return instance;
 }
 
+/*! \internal.
+ *
+ */
 ToolManager::ToolManager()
 {
 
 }
 
+/*! \brief Destructor.
+ *
+ */
 ToolManager::~ToolManager()
 {
 
 }
 
+/*! \brief Adds \a tool to the manager.
+ *
+ * The \l AbstractTool can be retrieved from the manager by supplying
+ * the tool name or by requesting it by type.
+ */
 void ToolManager::addTool(AbstractTool* tool)
 {
   if (!tool)
     return;
 
+  // when a tool is destroyed, remove it from the manager
+  QObject::connect(tool, &AbstractTool::destroyed, tool, [this, tool]()
+  {
+    auto it = m_tools.begin();
+    auto itEnd = m_tools.end();
+    for(; it != itEnd; ++it)
+    {
+      if (it.value() == tool)
+      {
+        m_tools.erase(it);
+        break;
+      }
+    }
+  });
+
   m_tools.insert(tool->toolName(), tool);
 }
 
+/*! \brief Retrieve the \l AbsgtractTool with the name \a toolName.
+ *
+ * return \c nullptr if the tool cannot be found.
+ */
 AbstractTool* ToolManager::tool(const QString& toolName) const
 {
   return m_tools[toolName];
 }
 
+/*! \brief Returns a begin iterator to the list of tools.
+ *
+ */
 ToolManager::ToolsList::iterator ToolManager::begin()
 {
   return m_tools.begin();
 }
 
+/*! \brief Returns an end iterator to the list of tools.
+ *
+ */
 ToolManager::ToolsList::iterator ToolManager::end()
 {
   return m_tools.end();
 }
 
+/*! \brief Returns a begin (const) iterator to the list of tools.
+ *
+ */
 ToolManager::ToolsList::const_iterator ToolManager::begin() const
 {
   return m_tools.cbegin();
 }
 
+/*! \brief Returns an end (const) iterator to the list of tools.
+ *
+ */
 ToolManager::ToolsList::const_iterator ToolManager::end() const
 {
   return m_tools.cend();


### PR DESCRIPTION
@michael-tims, @ldanzinger - please review the update to the ToolManager to remove tools which have been destroyed