### PR TITLE
allow the tool to be made visible when the active state changes

### DIFF
--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
@@ -84,6 +84,8 @@ Rectangle {
         onActiveChanged: {
             if (!active && coordinateConversionWindow.visible)
                 coordinateConversionWindow.visible = false;
+            else if (active && !coordinateConversionWindow.visible)
+                coordinateConversionWindow.visible = true;
         }
     }
 


### PR DESCRIPTION
@michael-tims please review the change to allow the coordinate tool to be set visible when it is made active (e.g. from the context menu)