### PR TITLE
allow the `GeoView` to be set as a `QObject`

### DIFF
--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
@@ -106,8 +106,10 @@ Item {
     /*!
       \qmlproperty int fontFamily
       \brief The font family for text on this tool.
+
+      The default is \c "helvetica".
      */
-    property string fontFamily: ""
+    property string fontFamily: "helvetica"
 
     /*!
       \qmlproperty bool expandUpwards

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
@@ -49,7 +49,9 @@ Item {
       \qmlproperty GeoView geoView
       \brief The GeoView for this tool. Should be a SceneQuickView or a MapQuickView.
      */
-    property alias geoView: coordinateConvController.geoView
+    property var geoView: null
+
+    onGeoViewChanged: coordinateConvController.setGeoView(geoView);
 
     /*!
       \qmlproperty bool captureMode

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
@@ -45,7 +45,10 @@ Item {
      */
     property color textColor: "black"
 
-    property var geoView: null
+    property alias geoView: coordinateConvController.geoView
+
+    property alias captureMode: coordinateConvController.captureMode
+    property alias inputFormat: coordinateConvController.inputFormat
 
     /*!
       \qmlproperty int highlightColor

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
@@ -45,9 +45,36 @@ Item {
      */
     property color textColor: "black"
 
+    /*!
+      \qmlproperty GeoView geoView
+      \brief The GeoView for this tool. Should be a SceneQuickView or a MapQuickView.
+     */
     property alias geoView: coordinateConvController.geoView
 
+    /*!
+      \qmlproperty bool captureMode
+      \brief Whether whether the tool is in capture mode.
+
+      If \c true, the tool will convert a point set via a mouse click.
+      If \c false, the too will use the app's current location as the target point.
+     */
     property alias captureMode: coordinateConvController.captureMode
+
+    /*!
+      \qmlproperty string inputFormat
+      \brief The input format for the tool. This can be in a user defined format or one of:
+
+      * \list
+        * \li \c DD. Decimal degrees.
+        * \li \c DDM. Degrees decimal minutes.
+        * \li \c DMS. Degrees minutes seconds.
+        * \li \c MGRS.
+        * \li \c USNG.
+        * \li \c UTM.
+        * \li \c GARS
+        * \li GeoRef
+      * \endList
+     */
     property alias inputFormat: coordinateConvController.inputFormat
 
     /*!

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
@@ -93,7 +93,7 @@ Item {
 
       The default value is \c "blue".
      */
-    property color backgroundColor: "white"
+    property color backgroundColor: "lightgrey"
 
     /*!
       \qmlproperty int fontSize

--- a/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionController.h
+++ b/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionController.h
@@ -22,10 +22,14 @@
 #include <QAbstractListModel>
 #include <QPointF>
 
+class QMouseEvent;
+
 namespace Esri
 {
 namespace ArcGISRuntime
 {
+  class GeoView;
+
 namespace Toolkit
 {
 
@@ -50,6 +54,8 @@ class TOOLKIT_EXPORT CoordinateConversionController : public AbstractTool
 
   // whether the tool is in "capture mode" (sets the target to a clicked point) or "live" mode (uses current location)
   Q_PROPERTY(bool captureMode READ isCaptureMode WRITE setCaptureMode NOTIFY captureModeChanged)
+
+  Q_PROPERTY(QObject* geoView READ geoView WRITE setGeoView NOTIFY geoViewChanged)
 
 public:
 
@@ -86,6 +92,7 @@ signals:
   void coordinateFormatsChanged();
   void inputFormatChanged();
   void captureModeChanged();
+  void geoViewChanged();
 
 public:
   CoordinateConversionController(QObject* parent = nullptr);
@@ -116,8 +123,12 @@ public:
   bool isCaptureMode() const;
   void setCaptureMode(bool captureMode);
 
+  QObject* geoView() const;
+  void setGeoView(QObject* geoView);
+
 public slots:
-  void onMouseClicked(const Esri::ArcGISRuntime::Point& clickedPoint);
+
+  void handleMouseClicked(QMouseEvent& clickedPoint);
   void onLocationChanged(const Esri::ArcGISRuntime::Point& location);
 
 private:
@@ -139,6 +150,7 @@ private:
   QStringList m_coordinateFormats;
   QString m_inputFormat;
   bool m_captureMode = false;
+  Esri::ArcGISRuntime::GeoView* m_geoView;
 };
 
 } // Toolkit

--- a/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionController.h
+++ b/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionController.h
@@ -13,12 +13,16 @@
 #ifndef COORDINATECONVERSIONCONTROLLER_H
 #define COORDINATECONVERSIONCONTROLLER_H
 
+
+// toolkit headers
 #include "AbstractTool.h"
 
-#include "SpatialReference.h"
-#include "Point.h"
+// qt_cpp headers
 #include "GeometryTypes.h"
+#include "Point.h"
+#include "SpatialReference.h"
 
+// Qt headers
 #include <QAbstractListModel>
 #include <QPointF>
 
@@ -125,7 +129,7 @@ public:
   void setCaptureMode(bool captureMode);
 
 public slots:
-  void onMouseClicked(QMouseEvent& clickedPoint);
+  void onMouseClicked(QMouseEvent& mouseEvent);
   void onLocationChanged(const Esri::ArcGISRuntime::Point& location);
 
 private:

--- a/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionController.h
+++ b/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionController.h
@@ -29,6 +29,8 @@ namespace Esri
 namespace ArcGISRuntime
 {
   class GeoView;
+  class MapView;
+  class SceneView;
 
 namespace Toolkit
 {
@@ -54,8 +56,6 @@ class TOOLKIT_EXPORT CoordinateConversionController : public AbstractTool
 
   // whether the tool is in "capture mode" (sets the target to a clicked point) or "live" mode (uses current location)
   Q_PROPERTY(bool captureMode READ isCaptureMode WRITE setCaptureMode NOTIFY captureModeChanged)
-
-  Q_PROPERTY(QObject* geoView READ geoView WRITE setGeoView NOTIFY geoViewChanged)
 
 public:
 
@@ -83,6 +83,8 @@ public:
   // remove the specified format from the set of results the tool will produce
   Q_INVOKABLE void removeCoordinateFormat(const QString& formatToRemove);
 
+  Q_INVOKABLE void setGeoView(QObject* geoView);
+
 signals:
   void optionsChanged();
   void resultsChanged();
@@ -92,7 +94,6 @@ signals:
   void coordinateFormatsChanged();
   void inputFormatChanged();
   void captureModeChanged();
-  void geoViewChanged();
 
 public:
   CoordinateConversionController(QObject* parent = nullptr);
@@ -123,16 +124,13 @@ public:
   bool isCaptureMode() const;
   void setCaptureMode(bool captureMode);
 
-  QObject* geoView() const;
-  void setGeoView(QObject* geoView);
-
 public slots:
   void onMouseClicked(QMouseEvent& clickedPoint);
   void onLocationChanged(const Esri::ArcGISRuntime::Point& location);
 
 private:
   CoordinateConversionResults* resultsInternal();
-
+  bool setGeoViewInternal(GeoView* geoView);
   Esri::ArcGISRuntime::Point pointFromNotation(const QString& incomingNotation);
   QString convertPointInternal(CoordinateConversionOptions* option, const Esri::ArcGISRuntime::Point& point) const;
 
@@ -149,7 +147,8 @@ private:
   QStringList m_coordinateFormats;
   QString m_inputFormat;
   bool m_captureMode = false;
-  Esri::ArcGISRuntime::GeoView* m_geoView;
+  Esri::ArcGISRuntime::MapView* m_mapView = nullptr;
+  Esri::ArcGISRuntime::SceneView* m_sceneView = nullptr;
 };
 
 } // Toolkit

--- a/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionController.h
+++ b/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionController.h
@@ -127,8 +127,7 @@ public:
   void setGeoView(QObject* geoView);
 
 public slots:
-
-  void handleMouseClicked(QMouseEvent& clickedPoint);
+  void onMouseClicked(QMouseEvent& clickedPoint);
   void onLocationChanged(const Esri::ArcGISRuntime::Point& location);
 
 private:

--- a/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
+++ b/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
@@ -273,9 +273,9 @@ void CoordinateConversionController::setGeoView(QObject* geoView)
 /*!
   \property CoordinateConversionController::results
   \brief The conversion results as a list model.
-  
+
   The results are automatically updated as conversions are run.
-  
+
   \sa CoordinateConversionResults
  */
 QAbstractListModel* CoordinateConversionController::results()

--- a/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
+++ b/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
@@ -609,7 +609,7 @@ QPointF CoordinateConversionController::screenCoordinate(double screenWidth, dou
     res = m_sceneView ? m_sceneView->locationToScreen(pointOnBoundary).screenPoint() : m_mapView->locationToScreen(pointOnBoundary);
   }
 
-  // enusre the returned point is within the bounds of the visisble screen
+  // ensure the returned point is within the bounds of the visible screen
   if (res.x() < 0.0)
     res.setX(0.0);
   else if (res.x() > screenWidth)

--- a/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
+++ b/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
@@ -79,7 +79,7 @@ CoordinateConversionController::CoordinateConversionController(QObject* parent):
     setSpatialReference(ToolResourceProvider::instance()->spatialReference());
   });
 
-  connect(ToolResourceProvider::instance(), &ToolResourceProvider::mouseClicked, this, &CoordinateConversionController::handleMouseClicked);
+  connect(ToolResourceProvider::instance(), &ToolResourceProvider::mouseClicked, this, &CoordinateConversionController::onMouseClicked);
 
   connect(ToolResourceProvider::instance(), &ToolResourceProvider::locationChanged, this, &CoordinateConversionController::onLocationChanged);
 
@@ -275,7 +275,7 @@ void CoordinateConversionController::setGeoView(QObject* geoView)
   if (!testView)
     return;
 
-  connect(geoView, SIGNAL(mouseClicked(QMouseEvent&)), this, SLOT(handleMouseClicked(QMouseEvent&)));
+  connect(geoView, SIGNAL(mouseClicked(QMouseEvent&)), this, SLOT(onMouseClicked(QMouseEvent&)));
 
   m_geoView = testView;
   emit geoViewChanged();
@@ -368,14 +368,24 @@ void CoordinateConversionController::setCaptureMode(bool captureMode)
 
   If the tool is active and in \l captureMode, this will be used as the input for conversions.
  */
-void CoordinateConversionController::handleMouseClicked(QMouseEvent& mouse)
+void CoordinateConversionController::onMouseClicked(QMouseEvent& mouse)
 {
   if (!isActive() || !isCaptureMode())
     return;
 
   SceneView* sceneView = dynamic_cast<SceneView*>(m_geoView);
   if (sceneView)
+  {
     setPointToConvert(sceneView->screenToBaseSurface(mouse.pos().x(), mouse.pos().y()));
+  }
+  else
+  {
+    MapView* mapView = dynamic_cast<MapView*>(m_geoView);
+    if (mapView)
+    {
+      setPointToConvert(mapView->screenToLocation(mouse.pos().x(), mouse.pos().y()));
+    }
+  }
 }
 
 /*!

--- a/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
+++ b/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
@@ -609,10 +609,16 @@ QPointF CoordinateConversionController::screenCoordinate(double screenWidth, dou
     res = m_sceneView ? m_sceneView->locationToScreen(pointOnBoundary).screenPoint() : m_mapView->locationToScreen(pointOnBoundary);
   }
 
-  res.setX(std::max(0.0, res.x()));
-  res.setY(std::max(0.0, res.y()));
-  res.setX(std::min(screenWidth, res.x()));
-  res.setY(std::min(screenHeight, res.y()));
+  // enusre the returned point is within the bounds of the visisble screen
+  if (res.x() < 0.0)
+    res.setX(0.0);
+  else if (res.x() > screenWidth)
+    res.setX(screenWidth);
+
+  if (res.y() < 0.0)
+    res.setY(0.0);
+  else if (res.y() > screenHeight)
+    res.setY(screenHeight);
 
   return res;
 }

--- a/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
+++ b/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
@@ -11,6 +11,8 @@
 //
 
 #include "CoordinateConversionController.h"
+
+// toolkit headers
 #include "CoordinateConversionConstants.h"
 #include "CoordinateConversionOptions.h"
 #include "CoordinateConversionResults.h"
@@ -18,16 +20,19 @@
 #include "ToolManager.h"
 #include "ToolResourceProvider.h"
 
+// qt_cpp headers
 #include "CoordinateFormatter.h"
-#include "GeometryEngine.h"
 #include "GeoView.h"
+#include "GeometryEngine.h"
 #include "MapView.h"
 #include "PolylineBuilder.h"
 #include "SceneView.h"
 
+// Qt headers
 #include <QClipboard>
 #include <QGuiApplication>
 
+// C++ headers
 #include <functional>
 
 /*!
@@ -364,19 +369,19 @@ void CoordinateConversionController::setCaptureMode(bool captureMode)
 }
 
 /*!
-  \brief Handles the mouse click at \a clickedPoint.
+  \brief Handles the mouse click at \a mouseEvent .
 
   If the tool is active and in \l captureMode, this will be used as the input for conversions.
  */
-void CoordinateConversionController::onMouseClicked(QMouseEvent& mouse)
+void CoordinateConversionController::onMouseClicked(QMouseEvent& mouseEvent )
 {
   if (!isActive() || !isCaptureMode())
     return;
 
   if (m_sceneView)
-    setPointToConvert(m_sceneView->screenToBaseSurface(mouse.pos().x(), mouse.pos().y()));
+    setPointToConvert(m_sceneView->screenToBaseSurface(mouseEvent .pos().x(), mouseEvent .pos().y()));
   else if (m_mapView)
-    setPointToConvert(m_mapView->screenToLocation(mouse.pos().x(), mouse.pos().y()));
+    setPointToConvert(m_mapView->screenToLocation(mouseEvent .pos().x(), mouseEvent .pos().y()));
 }
 
 /*!


### PR DESCRIPTION
@michael-tims, @JamesMBallard please review the changes to allow the `GeoView` to be supplied to the CoordinateController as a property.