### PR TITLE
James/avoid local tk build conflicts

### DIFF
--- a/Plugin/CppApi/ArcGISRuntimeToolkit.pri
+++ b/Plugin/CppApi/ArcGISRuntimeToolkit.pri
@@ -47,19 +47,19 @@ win32: {
   }
 }
 
-LIBS += -L$$PWD/output/$$PLATFORM_OUTPUT -lArcGISRuntimeToolkitCppApi$${ToolkitPrefix}$${DebugSuffix}
+# make sure the local toolkit libs come first on the link line
+SDK_LIBS = $$LIBS
+LIBS = -L$$PWD/output/$$PLATFORM_OUTPUT -lArcGISRuntimeToolkitCppApi$${ToolkitPrefix}$${DebugSuffix} $$SDK_LIBS
 
-# unset the previous toolkit path
+# unset the previous toolkit defines and import paths
 DEFINES -= ARCGIS_TOOLKIT_IMPORT_PATH=\"$$ARCGIS_TOOLKIT_IMPORT_PATH\"
+QML_IMPORT_PATH -= $${ARCGIS_TOOLKIT_IMPORT_PATH}
+QMLPATHS -= $${ARCGIS_TOOLKIT_IMPORT_PATH}
 
-# Set ArcGIS Runtime Toolkit Path for Qml UI files
+# Set and use the local toolkit defines and import paths
 ARCGIS_TOOLKIT_IMPORT_PATH = $$absolute_path($$PWD/../../Import)
 DEFINES += ARCGIS_TOOLKIT_IMPORT_PATH=\"$$ARCGIS_TOOLKIT_IMPORT_PATH\"
-
-# Add plugin paths to QML_IMPORT_PATH
 QML_IMPORT_PATH += $${ARCGIS_TOOLKIT_IMPORT_PATH}
-
-# Add plugin paths to QMLPATHS
 QMLPATHS += $${ARCGIS_TOOLKIT_IMPORT_PATH}
 
 # DEFINES

--- a/Plugin/CppApi/ArcGISRuntimeToolkit.pri
+++ b/Plugin/CppApi/ArcGISRuntimeToolkit.pri
@@ -48,8 +48,8 @@ win32: {
 }
 
 # make sure the local toolkit libs come first on the link line
-SDK_LIBS = $$LIBS
-LIBS = -L$$PWD/output/$$PLATFORM_OUTPUT -lArcGISRuntimeToolkitCppApi$${ToolkitPrefix}$${DebugSuffix} $$SDK_LIBS
+ARCGIS_RT_SDK_LIBS = $$LIBS
+LIBS = -L$$PWD/output/$$PLATFORM_OUTPUT -lArcGISRuntimeToolkitCppApi$${ToolkitPrefix}$${DebugSuffix} $$ARCGIS_RT_SDK_LIBS
 
 # unset the previous toolkit defines and import paths
 DEFINES -= ARCGIS_TOOLKIT_IMPORT_PATH=\"$$ARCGIS_TOOLKIT_IMPORT_PATH\"


### PR DESCRIPTION
Assigned to @khajra, please review.

This avoids conflicts with using a local toolkit build when building apps. We still had the toolkit Qml import paths set to the SDK install area which caused build and deployment problems.

Merging to master.