### PR TITLE
Fix up dynamic cast issues on mac

### DIFF
--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/TimeSlider.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/TimeSlider.qml
@@ -292,7 +292,7 @@ Item {
     }
 
     /*!
-      \qmlproperty GeoView geoView
+      \qmlproperty var geoView
       \brief The GeoView for this tool. Should be a SceneQuickView or a MapQuickView.
 
       This property is the entry point for the time extent of the geoView itself and
@@ -300,8 +300,7 @@ Item {
 
       \note this property must be set for the TimeSlider control to function correctly.
      */
-    property var geoView: null
-    onGeoViewChanged: controller.setGeoView(geoView);
+    property alias geoView: controller.geoView
 
     TimeSliderController {
         id: controller

--- a/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionController.h
+++ b/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionController.h
@@ -37,8 +37,8 @@ namespace Esri
 namespace ArcGISRuntime
 {
   class GeoView;
-  class MapView;
-  class SceneView;
+  class MapQuickView;
+  class SceneQuickView;
 
 namespace Toolkit
 {
@@ -155,8 +155,8 @@ private:
   QStringList m_coordinateFormats;
   QString m_inputFormat;
   bool m_captureMode = false;
-  Esri::ArcGISRuntime::MapView* m_mapView = nullptr;
-  Esri::ArcGISRuntime::SceneView* m_sceneView = nullptr;
+  Esri::ArcGISRuntime::MapQuickView* m_mapView = nullptr;
+  Esri::ArcGISRuntime::SceneQuickView* m_sceneView = nullptr;
 };
 
 } // Toolkit

--- a/Plugin/CppApi/include/TimeSliderController.h
+++ b/Plugin/CppApi/include/TimeSliderController.h
@@ -51,6 +51,7 @@ class TOOLKIT_EXPORT TimeSliderController : public AbstractTool
   Q_PROPERTY(int startStep READ startStep NOTIFY startStepChanged)
   Q_PROPERTY(int endStep READ endStep NOTIFY endStepChanged)
   Q_PROPERTY(QVariantList stepTimes READ stepTimes NOTIFY stepTimesChanged)
+  Q_PROPERTY(QObject* geoView READ geoView WRITE setGeoView NOTIFY geoViewChanged)
 
 signals:
   void numberOfStepsChanged();
@@ -59,6 +60,7 @@ signals:
   void startStepChanged();
   void endStepChanged();
   void stepTimesChanged();
+  void geoViewChanged();
 
 public:
   TimeSliderController(QObject* parent = nullptr);
@@ -66,7 +68,8 @@ public:
 
   QString toolName() const override;
 
-  Q_INVOKABLE void setGeoView(QObject* geoView);
+  QObject* geoView() const;
+  void setGeoView(QObject* geoView);
 
   int numberOfSteps() const;
 
@@ -93,7 +96,6 @@ private slots:
   void onSceneChanged();
 
 private:
-  bool setGeoViewInternal(GeoView* geoView);
   void initializeTimeProperties();
 
   void setNumberOfSteps(int numberOfSteps);

--- a/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
+++ b/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
@@ -39,7 +39,7 @@
 // STL headers
 #include <cmath>
 #include <functional>
-#include <string.h>
+#include <cstring>
 
 /*!
   \class Esri::ArcGISRuntime::Toolkit::CoordinateConversionController

--- a/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
+++ b/Plugin/CppApi/source/CoordinateConversion/CoordinateConversionController.cpp
@@ -39,6 +39,7 @@
 // STL headers
 #include <cmath>
 #include <functional>
+#include <string.h>
 
 /*!
   \class Esri::ArcGISRuntime::Toolkit::CoordinateConversionController
@@ -279,7 +280,7 @@ void CoordinateConversionController::setGeoView(QObject* geoView)
   if (!geoView)
     return;
 
-  if (strcmp(geoView->metaObject()->className(), MapQuickView::staticMetaObject.className()) == 0)
+  if (std::strcmp(geoView->metaObject()->className(), MapQuickView::staticMetaObject.className()) == 0)
   {
     m_mapView = reinterpret_cast<MapQuickView*>(geoView);
     m_sceneView = nullptr;
@@ -287,10 +288,9 @@ void CoordinateConversionController::setGeoView(QObject* geoView)
     {
       setSpatialReference(m_mapView->spatialReference());
       connect(m_mapView, &MapQuickView::mouseClicked, this, &CoordinateConversionController::onMouseClicked);
-
     }
   }
-  else if (strcmp(geoView->metaObject()->className(), SceneQuickView::staticMetaObject.className()) == 0)
+  else if (std::strcmp(geoView->metaObject()->className(), SceneQuickView::staticMetaObject.className()) == 0)
   {
     m_sceneView = reinterpret_cast<SceneQuickView*>(geoView);
     m_mapView = nullptr;
@@ -298,7 +298,6 @@ void CoordinateConversionController::setGeoView(QObject* geoView)
     {
       setSpatialReference(m_sceneView->spatialReference());
       connect(m_sceneView, &SceneQuickView::mouseClicked, this, &CoordinateConversionController::onMouseClicked);
-
     }
   }
 

--- a/Plugin/CppApi/source/TimeSliderController.cpp
+++ b/Plugin/CppApi/source/TimeSliderController.cpp
@@ -24,7 +24,6 @@
 #include "TimeValue.h"
 
 #include "TimeSliderController.h"
-#include "ToolResourceProvider.h"
 #include "ToolManager.h"
 
 using namespace Esri::ArcGISRuntime;
@@ -161,11 +160,6 @@ TimeSliderController::TimeSliderController(QObject* parent):
   AbstractTool(parent)
 {
   ToolManager::instance().addTool(this);
-
-  connect(ToolResourceProvider::instance(), &ToolResourceProvider::geoViewChanged, this, [this]()
-  {
-    setGeoViewInternal(Toolkit::ToolResourceProvider::instance()->geoView());
-  });
 }
 
 /*!
@@ -183,6 +177,16 @@ QString TimeSliderController::toolName() const
   return "TimeSlider";
 }
 
+QObject* TimeSliderController::geoView() const
+{
+  if (m_mapView)
+    return m_mapView;
+  else if (m_sceneView)
+    return m_sceneView;
+
+  return nullptr;
+}
+
 /*!
   \brief Sets the GeoView for this tool to \a geoView.
 
@@ -193,38 +197,31 @@ QString TimeSliderController::toolName() const
  */
 void TimeSliderController::setGeoView(QObject* geoView)
 {
-  setGeoViewInternal(dynamic_cast<GeoView*>(geoView));
-}
+  if (strcmp(geoView->metaObject()->className(), MapQuickView::staticMetaObject.className()) == 0)
+  {
+    m_mapView = reinterpret_cast<MapQuickView*>(geoView);
+    m_sceneView = nullptr;
 
-/*!
- \internal
- */
-bool TimeSliderController::setGeoViewInternal(GeoView* geoView)
-{
-  if (geoView == nullptr)
-    return false;
+    if (m_mapView)
+    {
+      connect(m_mapView, &MapQuickView::mapChanged, this, &TimeSliderController::onMapChanged);
+      onMapChanged();
+    }
+  }
+  else if (strcmp(geoView->metaObject()->className(), SceneQuickView::staticMetaObject.className()) == 0)
+  {
+    m_sceneView = reinterpret_cast<SceneQuickView*>(geoView);
+    m_mapView = nullptr;
+
+    if (m_sceneView)
+    {
+      connect(m_sceneView, &SceneQuickView::sceneChanged, this, &TimeSliderController::onSceneChanged);
+      onSceneChanged();
+    }
+  }
 
   calculateStepPositions();
   emit currentTimeExtentChanged();
-
-  m_sceneView = dynamic_cast<SceneQuickView*>(geoView);
-  m_mapView = dynamic_cast<MapQuickView*>(geoView);
-
-  if (m_sceneView)
-  {
-    connect(m_sceneView, &SceneQuickView::sceneChanged, this, &TimeSliderController::onSceneChanged);
-    onSceneChanged();
-  }
-  else if (m_mapView)
-  {
-    connect(m_mapView, &MapQuickView::mapChanged, this, &TimeSliderController::onMapChanged);
-    onMapChanged();
-  }
-
-  if (!m_operationalLayers)
-    return false;
-
-  return true;
 }
 
 /*!

--- a/Plugin/CppApi/source/TimeSliderController.cpp
+++ b/Plugin/CppApi/source/TimeSliderController.cpp
@@ -26,6 +26,8 @@
 #include "TimeSliderController.h"
 #include "ToolManager.h"
 
+#include <string.h>
+
 using namespace Esri::ArcGISRuntime;
 
 namespace Esri
@@ -197,7 +199,7 @@ QObject* TimeSliderController::geoView() const
  */
 void TimeSliderController::setGeoView(QObject* geoView)
 {
-  if (strcmp(geoView->metaObject()->className(), MapQuickView::staticMetaObject.className()) == 0)
+  if (std::strcmp(geoView->metaObject()->className(), MapQuickView::staticMetaObject.className()) == 0)
   {
     m_mapView = reinterpret_cast<MapQuickView*>(geoView);
     m_sceneView = nullptr;
@@ -208,7 +210,7 @@ void TimeSliderController::setGeoView(QObject* geoView)
       onMapChanged();
     }
   }
-  else if (strcmp(geoView->metaObject()->className(), SceneQuickView::staticMetaObject.className()) == 0)
+  else if (std::strcmp(geoView->metaObject()->className(), SceneQuickView::staticMetaObject.className()) == 0)
   {
     m_sceneView = reinterpret_cast<SceneQuickView*>(geoView);
     m_mapView = nullptr;

--- a/Plugin/CppApi/source/TimeSliderController.cpp
+++ b/Plugin/CppApi/source/TimeSliderController.cpp
@@ -26,7 +26,7 @@
 #include "TimeSliderController.h"
 #include "ToolManager.h"
 
-#include <string.h>
+#include <cstring>
 
 using namespace Esri::ArcGISRuntime;
 


### PR DESCRIPTION
@GuillaumeBelz please review the fix for the timeslider and coord conversion on mac:

don't use dynamic cast
remove resource provider