### PR TITLE
Allow users to know when tools are added

### DIFF
--- a/Plugin/CppApi/ArcGISRuntimeToolkit_StaticLib.pro
+++ b/Plugin/CppApi/ArcGISRuntimeToolkit_StaticLib.pro
@@ -14,7 +14,7 @@
 #  limitations under the License.
 ################################################################################
 
-# this is identical to the included project except it produces a statib library
+# this is identical to the included project except it produces a static library
 # rather than a dynamic library
 
 CONFIG += staticlib

--- a/Plugin/CppApi/include/ToolManager.h
+++ b/Plugin/CppApi/include/ToolManager.h
@@ -65,6 +65,7 @@ public:
 
 signals:
   void toolAdded(Esri::ArcGISRuntime::Toolkit::AbstractTool* tool);
+  void toolRemoved(const QString& toolName);
 
 private:
   ToolManager();

--- a/Plugin/CppApi/include/ToolManager.h
+++ b/Plugin/CppApi/include/ToolManager.h
@@ -32,7 +32,9 @@ namespace Toolkit
 
 class AbstractTool;
 
-class TOOLKIT_EXPORT ToolManager {
+class TOOLKIT_EXPORT ToolManager : public QObject
+{
+  Q_OBJECT
 
   using ToolsList = QMap<QString, AbstractTool*>;
 
@@ -60,6 +62,9 @@ public:
 
   ToolsList::const_iterator begin() const;
   ToolsList::const_iterator end() const;
+
+signals:
+  void toolAdded(Esri::ArcGISRuntime::Toolkit::AbstractTool* tool);
 
 private:
   ToolManager();

--- a/Plugin/CppApi/source/ToolManager.cpp
+++ b/Plugin/CppApi/source/ToolManager.cpp
@@ -91,6 +91,7 @@ void ToolManager::removeTool(AbstractTool* tool)
   {
     if (it.value() == tool)
     {
+      emit toolRemoved(it.key());
       m_tools.erase(it);
       return;
     }
@@ -144,6 +145,28 @@ ToolManager::ToolsList::const_iterator ToolManager::end() const
 {
   return m_tools.cend();
 }
+
+/*!
+  \fn void ToolManager::toolAdded(Esri::ArcGISRuntime::Toolkit::AbstractTool* tool);
+  \brief The signal emitted when a tool has been added to the ToolManager.
+
+  \list
+  \li \a tool - The tool that was added.
+  \endlist
+ */
+
+/*!
+  \fn void ToolManager::toolRemoved(const QString& toolName);
+  \brief The signal emitted when a tool has been removed from the ToolManager.
+
+  \list
+  \li \a toolName - The name of the tool that was removed.
+  \endlist
+
+  The name of the tool is provided instead of a pointer to the tool
+  like with \l toolAdded. This is for safety since the pointer may
+  be invalid when the tool has been removed.
+ */
 
 } // Toolkit
 } // ArcGISRuntime

--- a/Plugin/CppApi/source/ToolManager.cpp
+++ b/Plugin/CppApi/source/ToolManager.cpp
@@ -68,6 +68,7 @@ void ToolManager::addTool(AbstractTool* tool)
   });
 
   m_tools.insert(tool->toolName(), tool);
+  emit toolAdded(tool);
 }
 
 /*! \brief Removes the \l AbstractTool called \a toolName from the manager.


### PR DESCRIPTION
This is helpful if apps want to assign settings as soon as tools are added.

Assigned to @ldanzinger.

@lsmallwood and @ldanzinger to review.

Changes for **v.next** to allow the tool manager to notify watchers when tools are added. This goes along with https://github.com/Esri/dynamic-situational-awareness-qt/pull/283.

