### PR TITLE
adding CurrentVersion.qml

### DIFF
--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CurrentVersion.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CurrentVersion.qml
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ *  Copyright 2012-2018 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+
+/*!
+  \internal
+  This QML file is only used for incrementing the current version of the toolkit and
+  should not be used in your application.
+*/
+import QtQuick 2.2
+
+Component {}

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/qmldir
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/qmldir
@@ -19,3 +19,4 @@ module Esri.ArcGISRuntime.Toolkit.Controls.CppApi
 CoordinateConversion 100.2 CoordinateConversion.qml
 ArcGISCompass 100.2 ArcGISCompass.qml
 TimeSlider 100.3 TimeSlider.qml
+CurrentVersion 100.4 CurrentVersion.qml

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/QmlApi/CurrentVersion.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/QmlApi/CurrentVersion.qml
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ *  Copyright 2012-2018 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+
+/*!
+  \internal
+  This QML file is only used for incrementing the current version of the toolkit and
+  should not be used in your application.
+*/
+import QtQuick 2.2
+
+Component {}

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/QmlApi/qmldir
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/QmlApi/qmldir
@@ -17,3 +17,4 @@
 module Esri.ArcGISRuntime.Toolkit.Controls.QmlApi
 
 TimeSlider 100.3 TimeSlider.qml
+CurrentVersion 100.4 CurrentVersion.qml


### PR DESCRIPTION
adding dummy CurrentVersion.qml to allow for importing current version without upping any specific toolkit

Found while testing DSA with 100.4, but no toolkit components are updated to 100.4 yet.

@JamesMBallard please review/merge