### PR TITLE
SslHandshakeView dialog now uses QuickControls 2. Made

### DIFF
--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/Dialogs.qrc
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/Dialogs.qrc
@@ -13,6 +13,7 @@
         <file>SimpleDialog20.qml</file>
         <file>SslHandshakeView.qml</file>
         <file>SslHandshakeView20.qml</file>
+        <file>SslHandshakeView100.qml</file>
         <file>UserCredentialsView.qml</file>
         <file>UserCredentialsView20.qml</file>
         <file>UserCredentialsView100.qml</file>

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/SslHandshakeView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/SslHandshakeView.qml
@@ -68,8 +68,6 @@ Rectangle {
         onWheel: wheel.accepted = true
     }
 
-
-
     Rectangle {
         color: "white"
         border {
@@ -83,8 +81,6 @@ Rectangle {
         anchors.centerIn: parent
         width: childrenRect.width
         height: childrenRect.height
-
-
 
         GridLayout {
             id: gridLayout

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/SslHandshakeView100.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/SslHandshakeView100.qml
@@ -14,9 +14,8 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Layouts 1.3
+import QtQuick 2.5
+import QtQuick.Controls 1.4
 import QtGraphicalEffects 1.0
 import QtQuick.Window 2.0
 
@@ -52,7 +51,8 @@ Rectangle {
     /*! \internal */
     property string detailText: qsTr("The server could not prove itself; its security certificate is not trusted by your OS. Would you like to continue anyway?")
     /*! \internal */
-    property real displayScaleFactor: 1
+    property real displayScaleFactor: (Screen.logicalPixelDensity * 25.4) / (Qt.platform.os === "windows" || Qt.platform.os === "linux" ? 96 : 72)
+
     RadialGradient {
         anchors.fill: parent
         opacity: 0.7
@@ -68,9 +68,11 @@ Rectangle {
         onWheel: wheel.accepted = true
     }
 
-
-
     Rectangle {
+        anchors {
+            fill: banner
+            margins: -1 * displayScaleFactor
+        }
         color: "white"
         border {
             color: "black"
@@ -80,88 +82,99 @@ Rectangle {
         smooth: true
         clip: true
         antialiasing: true
-        anchors.centerIn: parent
-        width: childrenRect.width
-        height: childrenRect.height
+    }
 
+    Image {
+        id: banner
+        anchors {
+            centerIn: parent
+            verticalCenterOffset: -50 * displayScaleFactor
+        }
+        width: 224 * displayScaleFactor
+        height: 50 * displayScaleFactor
+        clip: true
+        source: "images/banner.png"
 
+        Column {
+            anchors {
+                fill: parent
+                margins: 5 * displayScaleFactor
+            }
 
-        GridLayout {
-            id: gridLayout
-            columns: 2
+            spacing: 2 * displayScaleFactor
 
-            Rectangle {
-                Layout.fillWidth: true
-                Layout.columnSpan: 2
-                Layout.column: 0
+            Text {
+                anchors.horizontalCenter: parent.horizontalCenter
+                text: qsTr("Untrusted Host")
+                font {
+                    pixelSize: 18 * displayScaleFactor
+                    family: "sanserif"
+                }
+                renderType: Text.NativeRendering
                 color: "white"
-                border {
-                    color: "black"
-                    width: 1 * displayScaleFactor
-                }
-                radius: 3
-                smooth: true
-                antialiasing: true
-                clip:true
-                Layout.minimumWidth: childrenRect.width
-                Layout.minimumHeight: childrenRect.height
-
-                Image {
-                    anchors.fill: parent
-                    source: "images/banner.png"
-                }
-
-                ColumnLayout {
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    Text {
-                        Layout.fillWidth: true
-                        text: qsTr("Untrusted Host")
-                        horizontalAlignment: Qt.AlignHCenter
-                        padding: 5
-                        font {
-                            pixelSize: 18 * displayScaleFactor
-                            family: "sanserif"
-                        }
-                        color: "white"
-                    }
-
-                    Text {
-                        elide: Text.ElideRight
-                        Layout.fillWidth: true
-                        text: requestingHost
-                        horizontalAlignment: Qt.AlignHCenter
-                        font {
-                            pixelSize: 12 * displayScaleFactor
-                            family: "sanserif"
-                        }
-                        color: "white"
-                    }
-                }
             }
 
             Text {
-                text: detailText
-                Layout.fillWidth: true
-                Layout.margins: 10
-                Layout.columnSpan: 2
-                Layout.alignment: Qt.AlignHCenter
-                wrapMode: Text.Wrap
+                anchors.horizontalCenter: parent.horizontalCenter
+                elide: Text.ElideRight
+                text: requestingHost
                 font {
-                    pixelSize: 10 * displayScaleFactor
+                    pixelSize: 12 * displayScaleFactor
                     family: "sanserif"
                 }
+                color: "white"
             }
+        }
+    }
 
-            CheckBox {
-                id: rememberCheckbox
-                Layout.fillWidth: true
-                Layout.columnSpan: 2
-                text: qsTr("Remember")
+    Rectangle {
+        anchors {
+            fill: controlsColumn
+            margins: -5 * displayScaleFactor
+        }
+        color: "white"
+        border {
+            color: "black"
+            width: 1 * displayScaleFactor
+        }
+        radius: 3
+        smooth: true
+        clip: true
+        antialiasing: true
+    }
+
+    Column {
+        id: controlsColumn
+        anchors {
+            top: banner.bottom
+            topMargin: 5 * displayScaleFactor
+            horizontalCenter: banner.horizontalCenter
+        }
+        width: 215 * displayScaleFactor
+        spacing: 8 * displayScaleFactor
+
+        Text {
+            anchors.horizontalCenter: parent.horizontalCenter
+            text: detailText
+            width: parent.width
+            wrapMode: Text.Wrap
+            font {
+                pixelSize: 10 * displayScaleFactor
+                family: "sanserif"
             }
+        }
+
+        CheckBox {
+            id: rememberCheckbox
+            text: qsTr("Remember")
+        }
+
+        Row {
+            width: parent.width
+            spacing: 4 * displayScaleFactor
 
             Button {
-                Layout.margins: 10
-                Layout.alignment: Qt.AlignLeft
+                width: ((parent.width / 2) - 2 * displayScaleFactor)
                 text: qsTr("Block")
                 onClicked: {
                     // reject the challenge and let the resource fail to load
@@ -172,9 +185,7 @@ Rectangle {
             }
 
             Button {
-                id: continueButton
-                Layout.margins: 10
-                Layout.alignment: Qt.AlignRight
+                width: ((parent.width / 2) - 2 * displayScaleFactor)
                 text: qsTr("Trust")
                 onClicked: {
                     // continue SSL handshake and trust host

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/UserCredentialsView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/UserCredentialsView.qml
@@ -104,6 +104,7 @@ Rectangle {
         width: childrenRect.width
         height: childrenRect.height
 
+
         GridLayout {
             columns: 2
 
@@ -111,11 +112,10 @@ Rectangle {
                 id: banner
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillWidth: true
-                Layout.minimumWidth: childrenRect.width
                 Layout.columnSpan: 2
                 Layout.margins: 1
-                width: childrenRect.width
-                height: childrenRect.height
+                Layout.minimumWidth: childrenRect.width
+                Layout.minimumHeight: childrenRect.height
 
                 color: "white"
                 border {
@@ -127,20 +127,21 @@ Rectangle {
                 antialiasing: true
 
                 Image {
-                    width: childrenRect.width
-                    height: childrenRect.height
+                    anchors.fill: parent
                     source: "images/banner.png"
+                }
 
-                    Text {
-                        id: titleText
-                        text: qsTr("Authentication Required")
-                        padding: 5
-                        font {
-                            pixelSize: 18 * displayScaleFactor
-                            family: "sanserif"
-                        }
-                        color: "white"
+                Text {
+                    id: titleText
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    text: qsTr("Authentication Required")
+                    padding: 5
+                    horizontalAlignment: Qt.AlignHCenter
+                    font {
+                        pixelSize: 18 * displayScaleFactor
+                        family: "sanserif"
                     }
+                    color: "white"
                 }
             }
 

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/qmldir
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/qmldir
@@ -26,7 +26,8 @@ OAuth2View 2.0 OAuth2View20.qml
 OAuth2View 100.0 OAuth2View.qml
 SimpleDialog 2.0 SimpleDialog20.qml
 SslHandshakeView 2.0 SslHandshakeView20.qml
-SslHandshakeView 100.0 SslHandshakeView.qml
+SslHandshakeView 100.0 SslHandshakeView100.qml
+SslHandshakeView 100.4 SslHandshakeView.qml
 UserCredentialsView 2.0 UserCredentialsView20.qml
 UserCredentialsView 100.0 UserCredentialsView100.qml
 UserCredentialsView 100.4 UserCredentialsView.qml


### PR DESCRIPTION
SslHandshakeView dialog now uses QuickControls 2. Made tweak to UserCredentialsView so renders correctly in QtQuick Preview rendering.

I am unable to trigger "Untrusted host" in sample "Open Map (URL)" to test on mobile platforms. Preview renders as expected on Desktop.

Structure of changes is exact same as changes made to UserCredentials dialog. I'm confident there will not be issues on mobile.