### PR TITLE
Ldanzinger/controls2 upgrade

### DIFF
--- a/Examples/CalloutExample.qml
+++ b/Examples/CalloutExample.qml
@@ -14,10 +14,10 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.3
-import QtQuick.Controls 1.2
-import QtPositioning 5.3
-import QtSensors 5.3
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+import QtPositioning 5.8
+import QtSensors 5.9
 import Esri.ArcGISRuntime 100.5
 import Esri.ArcGISExtras 1.1
 import Esri.ArcGISRuntime.Toolkit.Controls 100.5
@@ -41,7 +41,7 @@ Rectangle {
             FeatureLayer {
                 id: featureLayer
                 ServiceFeatureTable {
-                    url: "http://holistic30.esri.com:6080/arcgis/rest/services/DamageInspection6/FeatureServer/0"
+                    url: "http://sampleserver6.arcgisonline.com/arcgis/rest/services/DamageAssessment/FeatureServer/0"
                 }
             }
 

--- a/Examples/Examples.qml
+++ b/Examples/Examples.qml
@@ -14,8 +14,8 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.0
-import QtQuick.Controls 1.1
+import QtQuick 2.11
+import QtQuick.Controls 2.4
 import QtGraphicalEffects 1.0
 import Esri.ArcGISRuntime 100.5
 

--- a/Examples/PopupExample.qml
+++ b/Examples/PopupExample.qml
@@ -14,10 +14,10 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.6
-import QtQuick.Controls 1.5
-import QtPositioning 5.3
-import QtSensors 5.3
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+import QtPositioning 5.8
+import QtSensors 5.9
 import QtQuick.Dialogs 1.2
 import Esri.ArcGISRuntime 100.5
 import Esri.ArcGISExtras 1.1

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/Callout.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/Callout.qml
@@ -14,10 +14,9 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.4
-import QtQuick.Window 2.2
-import QtQuick.Layouts 1.1
-import QtQuick.Window 2.0
+import QtQuick 2.11
+import QtQuick.Window 2.11
+import QtQuick.Layouts 1.3
 import "LeaderPosition.js" as Enums
 
 /*!

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/ArcGISCompass.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/ArcGISCompass.qml
@@ -14,10 +14,8 @@
  *  limitations under the License.
  ******************************************************************************/
  
-import QtQuick 2.6
-import QtQuick.Window 2.2
-import QtQuick.Controls 1.4
-import QtQuick.Controls.Styles 1.4
+import QtQuick 2.11
+import QtQuick.Window 2.11
 import Esri.ArcGISRuntime.Toolkit.CppApi 100.3
 
 /*!

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/TimeSlider.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/TimeSlider.qml
@@ -14,10 +14,10 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Window 2.2
-import QtQuick.Layouts 1.1
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+import QtQuick.Window 2.11
+import QtQuick.Layouts 1.3
 import Esri.ArcGISRuntime.Toolkit.CppApi 100.3
 
 /*!

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupStackView1004.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupStackView1004.qml
@@ -14,9 +14,11 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.11
-import QtQuick.Controls 2.4
+import QtQuick 2.4
+import QtQuick.Controls 1.4
+import QtQuick.Controls.Styles 1.4
 import QtQuick.Dialogs 1.2
+import QtQuick.Window 2.0
 
 /*!
     \qmltype PopupStackView

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupView.qml
@@ -14,9 +14,9 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.4
+import QtQuick 2.11
 import QtQuick.Dialogs 1.2
-import QtQuick.Window 2.0
+import QtQuick.Window 2.11
 
 /*!
     \qmltype PopupView

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupViewBase.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/PopupViewBase.qml
@@ -14,9 +14,9 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.4
+import QtQuick 2.11
 import QtQuick.Dialogs 1.2
-import QtQuick.Window 2.0
+import QtQuick.Window 2.11
 
 Item {
     id: popupViewBase

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/QmlApi/TimeSlider.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/QmlApi/TimeSlider.qml
@@ -14,10 +14,10 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
-import QtQuick.Window 2.2
-import QtQuick.Layouts 1.1
+import QtQuick 2.11
+import QtQuick.Controls 2.4
+import QtQuick.Window 2.11
+import QtQuick.Layouts 1.3
 
 /*!
     \qmltype TimeSlider

--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/qmldir
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/qmldir
@@ -35,6 +35,7 @@ PopupView 100.5 PopupView.qml
 internal PopupViewBase101 PopupViewBase1001.qml
 internal PopupViewBase PopupViewBase.qml
 PopupStackView 100.2 PopupStackView1002.qml
+PopupStackView 100.4 PopupStackView1004.qml
 PopupStackView 100.5 PopupStackView.qml
 RotationToolbar 2.0 RotationToolbar20.qml
 SearchBox 2.0 SearchBox20.qml

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/AuthenticationView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/AuthenticationView.qml
@@ -14,7 +14,7 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.5
+import QtQuick 2.11
 
 /*!
     \qmltype AuthenticationView

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/ClientCertificateView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/ClientCertificateView.qml
@@ -14,11 +14,11 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.5
-import QtQuick.Controls 1.4
+import QtQuick 2.11
+import QtQuick.Controls 2.4
 import QtQuick.Dialogs 1.2
 import QtGraphicalEffects 1.0
-import QtQuick.Window 2.0
+import QtQuick.Window 2.11
 
 /*!
     \qmltype ClientCertificateView
@@ -45,6 +45,13 @@ Rectangle {
          requires no configuration.
     */
     property var challenge
+
+    /*!
+        \brief The color of the top banner in the view.
+
+        The default is blue, #005e95.
+    */
+    property color bannerColor: "#005e95"
 
     /*! \internal */
     property string detailText: qsTr("The service has requested a client certificate to authenticate you. The app has identified the requesting server as '%1', but you should only give the app access to the certificate if you trust it.").arg(requestingHost)
@@ -76,31 +83,15 @@ Rectangle {
         height: banner.height + controlsColumn.height
 
         Rectangle {
-            anchors {
-                fill: banner
-                margins: -1
-            }
-            color: "white"
-            border {
-                color: "black"
-                width: 1
-            }
-            radius: 3
-            smooth: true
-            clip: true
-            antialiasing: true
-        }
-
-        Image {
             id: banner
             anchors {
                 top: parent.top
                 horizontalCenter: parent.horizontalCenter
             }
-            width: 224
+            width: 225
             height: 50
             clip: true
-            source: "images/banner.png"
+            color: bannerColor
 
             Column {
                 anchors {
@@ -141,11 +132,6 @@ Rectangle {
                 margins: -5
             }
             color: "white"
-            border {
-                color: "black"
-                width: 1
-            }
-            radius: 3
             smooth: true
             clip: true
             antialiasing: true

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/OAuth2View.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/OAuth2View.qml
@@ -14,7 +14,7 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.5
+import QtQuick 2.11
 import QtWebView 1.1
 
 /*!

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/SslHandshakeView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/SslHandshakeView.qml
@@ -14,11 +14,11 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick 2.11
+import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.3
 import QtGraphicalEffects 1.0
-import QtQuick.Window 2.0
+import QtQuick.Window 2.11
 
 /*!
     \qmltype SslHandshakeView
@@ -47,6 +47,13 @@ Rectangle {
     */
     property var challenge
 
+    /*!
+        \brief The color of the top banner in the view.
+
+        The default is blue, #005e95.
+    */
+    property color bannerColor: "#005e95"
+
     /*! \internal */
     property string requestingHost: challenge ? challenge.authenticatingHost : ""
     /*! \internal */
@@ -68,10 +75,6 @@ Rectangle {
 
     Rectangle {
         color: "white"
-        border {
-            color: "black"
-            width: 1
-        }
         radius: 3
         smooth: true
         clip: true
@@ -89,10 +92,6 @@ Rectangle {
                 Layout.columnSpan: 2
                 Layout.column: 0
                 color: "white"
-                border {
-                    color: "black"
-                    width: 1
-                }
                 radius: 3
                 smooth: true
                 antialiasing: true
@@ -100,9 +99,9 @@ Rectangle {
                 Layout.minimumWidth: childrenRect.width
                 Layout.minimumHeight: childrenRect.height
 
-                Image {
+                Rectangle {
                     anchors.fill: parent
-                    source: "images/banner.png"
+                    color: bannerColor
                 }
 
                 ColumnLayout {

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/UserCredentialsView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/UserCredentialsView.qml
@@ -113,7 +113,6 @@ Rectangle {
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillWidth: true
                 Layout.columnSpan: 2
-                //Layout.margins: 1
                 Layout.minimumWidth: childrenRect.width
                 Layout.minimumHeight: childrenRect.height
 

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/UserCredentialsView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/UserCredentialsView.qml
@@ -14,8 +14,8 @@
  *  limitations under the License.
  ******************************************************************************/
 
-import QtQuick 2.6
-import QtQuick.Controls 2.2
+import QtQuick 2.11
+import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.3
 import QtGraphicalEffects 1.0
 import QtQuick.Window 2.0
@@ -55,6 +55,13 @@ Rectangle {
     */
     property var challenge
 
+    /*!
+        \brief The color of the top banner in the view.
+
+        The default is blue, #005e95.
+    */
+    property color bannerColor: "#005e95"
+
     /*! \internal */
     property string requestingHost: challenge ? challenge.authenticatingHost : ""
     /*! \internal */
@@ -89,12 +96,7 @@ Rectangle {
 
 
     Rectangle {
-        color: "white"
-        border {
-            color: "black"
-            width: 1
-        }
-        radius: 3
+        color: "white"        
         smooth: true
         clip: true
         antialiasing: true
@@ -111,22 +113,17 @@ Rectangle {
                 Layout.alignment: Qt.AlignHCenter
                 Layout.fillWidth: true
                 Layout.columnSpan: 2
-                Layout.margins: 1
+                //Layout.margins: 1
                 Layout.minimumWidth: childrenRect.width
                 Layout.minimumHeight: childrenRect.height
 
-                color: "white"
-                border {
-                    color: "black"
-                    width: 1
-                }
-                radius: 3
+                color: "white"                
                 smooth: true
                 antialiasing: true
 
-                Image {
+                Rectangle {
                     anchors.fill: parent
-                    source: "images/banner.png"
+                    color: bannerColor
                 }
 
                 Text {


### PR DESCRIPTION
@JamesMBallard please review/merge. I am updating QtQuickControls to version 2, as well as upping all the other imports for 5.12 - many were quite old. I also removed the purple banner image in the dialogs to be a plain rectangle that uses a default color (the blue from the sample viewer). Users can then customize look and feel which is common in the Controls 2 via the Materials conf file, whereas the image was static.