### PR TITLE
We don't need the full include here.

### DIFF
--- a/Plugin/CppApi/source/ArcGISRuntimeToolkit.cpp
+++ b/Plugin/CppApi/source/ArcGISRuntimeToolkit.cpp
@@ -16,7 +16,7 @@
  ******************************************************************************/
 
 #include "ArcGISRuntimeToolkit.h"
-#include <QtQml>
+#include <QtQml/qqml.h>
 
 #include "ArcGISCompassController.h"
 #include "CoordinateConversionController.h"


### PR DESCRIPTION
Bringing in <QtQml> also brings in qendian.h which has compile
errors with Qt 5.12.0 using gcc 4.8.x series compilers.

