### PR TITLE
Parse webview title in onTitleChanged signal handler

### DIFF
--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/OAuth2View.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/OAuth2View.qml
@@ -48,16 +48,20 @@ WebView {
 
     onLoadingChanged: {
         if (loadRequest.status === WebView.LoadSucceededStatus) {
-            if (title.indexOf("SUCCESS code=") > -1) {
-                var authCode = title.replace("SUCCESS code=", "");
-                if (challenge)
-                    challenge.continueWithOAuthAuthorizationCode(authCode);
-                webView.visible = false;
-            } else if (title.indexOf("Denied error=") > -1) {
-                if (challenge)
-                    challenge.cancel();
-                webView.visible = false;
-            }
+            forceActiveFocus();
+        }
+    }
+
+    onTitleChanged: {
+        if (title.indexOf("SUCCESS code=") > -1) {
+            var authCode = title.replace("SUCCESS code=", "");
+            if (challenge)
+                challenge.continueWithOAuthAuthorizationCode(authCode);
+            webView.visible = false;
+        } else if (title.indexOf("Denied error=") > -1) {
+            if (challenge)
+                challenge.cancel();
+            webView.visible = false;
         }
     }
 }

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/OAuth2View100.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/OAuth2View100.qml
@@ -48,16 +48,20 @@ WebView {
 
     onLoadingChanged: {
         if (loadRequest.status === WebView.LoadSucceededStatus) {
-            if (title.indexOf("SUCCESS code=") > -1) {
-                var authCode = title.replace("SUCCESS code=", "");
-                if (challenge)
-                    challenge.continueWithOAuthAuthorizationCode(authCode);
-                webView.visible = false;
-            } else if (title.indexOf("Denied error=") > -1) {
-                if (challenge)
-                    challenge.cancel();
-                webView.visible = false;
-            }
+            forceActiveFocus();
+        }
+    }
+
+    onTitleChanged: {
+        if (title.indexOf("SUCCESS code=") > -1) {
+            var authCode = title.replace("SUCCESS code=", "");
+            if (challenge)
+                challenge.continueWithOAuthAuthorizationCode(authCode);
+            webView.visible = false;
+        } else if (title.indexOf("Denied error=") > -1) {
+            if (challenge)
+                challenge.cancel();
+            webView.visible = false;
         }
     }
 }


### PR DESCRIPTION
@ldanzinger Can you please review and merge?

In some Enterprise login scenarios, we found that the webview title and url changes happen after the load has finished.  As recommended by the Qt Company developer in [QTBUG-67629](https://bugreports.qt.io/browse/QTBUG-67629), this PR includes changes for parsing the webview title in `onTitleChanged` signal handler instead of `onLoadingChanged`. 

Also, `onLoadingChanged` handler has been updated to automatically set the focus in the username field once webview finishes loading.

@nmanocha 