### PR TITLE
updating controls to have a default color

### DIFF
--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/ClientCertificateView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/ClientCertificateView.qml
@@ -101,7 +101,7 @@ Rectangle {
 
                 spacing: 2
 
-                Text {
+                Label {
                     anchors.horizontalCenter: parent.horizontalCenter
                     text: qsTr("Client Certificate Requested")
                     font {
@@ -112,7 +112,7 @@ Rectangle {
                     renderType: Text.NativeRendering
                 }
 
-                Text {
+                Label {
                     anchors.horizontalCenter: parent.horizontalCenter
                     elide: Text.ElideRight
                     text: requestingHost
@@ -147,7 +147,7 @@ Rectangle {
             width: 215
             spacing: 5
 
-            Text {
+            Label {
                 anchors.horizontalCenter: parent.horizontalCenter
                 text: detailText
                 width: parent.width
@@ -156,10 +156,11 @@ Rectangle {
                     pixelSize: 10
                     family: "sanserif"
                 }
+                color: "black"
                 renderType: Text.NativeRendering
             }
 
-            Text {
+            Label {
                 anchors.horizontalCenter: parent.horizontalCenter
                 text: qsTr("Available Certificates:")
                 width: parent.width
@@ -168,6 +169,7 @@ Rectangle {
                     pixelSize: 12
                     family: "sanserif"
                 }
+                color: "black"
                 renderType: Text.NativeRendering
             }
 

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/SslHandshakeView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/SslHandshakeView.qml
@@ -106,7 +106,7 @@ Rectangle {
 
                 ColumnLayout {
                     anchors.horizontalCenter: parent.horizontalCenter
-                    Text {
+                    Label {
                         Layout.fillWidth: true
                         text: qsTr("Untrusted Host")
                         horizontalAlignment: Qt.AlignHCenter
@@ -118,7 +118,7 @@ Rectangle {
                         color: "white"
                     }
 
-                    Text {
+                    Label {
                         elide: Text.ElideRight
                         Layout.fillWidth: true
                         text: requestingHost
@@ -132,13 +132,14 @@ Rectangle {
                 }
             }
 
-            Text {
+            Label {
                 text: detailText
                 Layout.fillWidth: true
                 Layout.margins: 10
                 Layout.columnSpan: 2
                 Layout.alignment: Qt.AlignHCenter
                 wrapMode: Text.Wrap
+                color: "black"
                 font {
                     pixelSize: 10
                     family: "sanserif"

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/UserCredentialsView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/UserCredentialsView.qml
@@ -125,7 +125,7 @@ Rectangle {
                     color: bannerColor
                 }
 
-                Text {
+                Label {
                     id: titleText
                     anchors.horizontalCenter: parent.horizontalCenter
                     text: qsTr("Authentication Required")
@@ -148,7 +148,7 @@ Rectangle {
                 height: childrenRect.height
                 visible: challenge ? challenge.failureCount > 1 : false
 
-                Text {
+                Label {
                     text: qsTr("Invalid username or password.")
                     font {
                         pixelSize: 12
@@ -158,7 +158,7 @@ Rectangle {
                 }
             }
 
-            Text {
+            Label {
                 text: detailText
                 Layout.fillWidth: true
                 Layout.rightMargin: 10
@@ -167,13 +167,14 @@ Rectangle {
                 Layout.columnSpan: 2
                 Layout.alignment: Qt.AlignHCenter
                 wrapMode: Text.Wrap
+                color: "black"
                 font {
                     pixelSize: 12
                     family: "sanserif"
                 }
             }
 
-            Text {
+            Label {
                 text: requestingHost
                 Layout.fillWidth: true
                 Layout.rightMargin: 10
@@ -181,6 +182,7 @@ Rectangle {
                 Layout.bottomMargin: 10
                 Layout.columnSpan: 2
                 wrapMode: Text.Wrap
+                color: "black"
                 font {
                     pixelSize: 12
                     family: "sanserif"
@@ -193,6 +195,8 @@ Rectangle {
                 Layout.margins: 10
                 Layout.columnSpan: 2
                 placeholderText: qsTr("username")
+                placeholderTextColor: "darkgray"
+                color: "black"
             }
 
             TextField {
@@ -201,7 +205,9 @@ Rectangle {
                 Layout.margins: 10
                 Layout.columnSpan: 2
                 placeholderText: qsTr("password")
+                placeholderTextColor: "darkgray"
                 echoMode: TextInput.Password
+                color: "black"
             }
 
             Button {


### PR DESCRIPTION
@JamesMBallard please review/merge.

We need some defaults on the colors since we explicitly set the background color of the dialogs to be white. We run into issues on dark mode on mac.

For example, here is how it looks in light mode:

![screen shot 2019-01-29 at 10 54 50 am](https://user-images.githubusercontent.com/4107363/51925422-a6bcfe80-23b4-11e9-83c7-1ec1ac11ed63.png)

But when you switch to dark mode, you get this:

![screen shot 2019-01-29 at 10 54 04 am](https://user-images.githubusercontent.com/4107363/51925449-b0defd00-23b4-11e9-84af-6ce276046ecb.png)

Setting the colors explicitly looks exactly the same for light mode, and improves dark mode to:

![screen shot 2019-01-29 at 10 54 25 am](https://user-images.githubusercontent.com/4107363/51925477-c05e4600-23b4-11e9-8542-365b494976c1.png)


