### PR TITLE
add override, change Q_DECL_OVERRIDE by override, fix indentation

### DIFF
--- a/Plugin/ArcGISRuntimeToolkitPlugin.h
+++ b/Plugin/ArcGISRuntimeToolkitPlugin.h
@@ -26,7 +26,7 @@ class ArcGISRuntimeToolkitPlugin : public QQmlExtensionPlugin
 
 public:
   explicit ArcGISRuntimeToolkitPlugin(QObject* parent = nullptr);
-  void registerTypes(const char* uri) Q_DECL_OVERRIDE;
+  void registerTypes(const char* uri) override;
 };
 
 #endif // ArcGISRuntimeToolkitPlugin_H

--- a/Plugin/CppApi/include/AbstractTool.h
+++ b/Plugin/CppApi/include/AbstractTool.h
@@ -43,7 +43,7 @@ class TOOLKIT_EXPORT AbstractTool : public QObject
 
 public:
   AbstractTool(QObject* parent = nullptr);
-  virtual ~AbstractTool();
+  ~AbstractTool() override;
 
   virtual QString toolName() const = 0;
   virtual bool handleClick(const Point& pos);

--- a/Plugin/CppApi/include/ArcGISCompassController.h
+++ b/Plugin/CppApi/include/ArcGISCompassController.h
@@ -46,7 +46,7 @@ signals:
 
 public:
   ArcGISCompassController(QObject *parent = nullptr);
-  ~ArcGISCompassController();
+  ~ArcGISCompassController() override;
 
   bool setView(Esri::ArcGISRuntime::GeoView* geoView);
   /*! \internal */

--- a/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionController.h
+++ b/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionController.h
@@ -109,7 +109,7 @@ signals:
 
 public:
   CoordinateConversionController(QObject* parent = nullptr);
-  ~CoordinateConversionController();
+  ~CoordinateConversionController() override;
 
   void setSpatialReference(const Esri::ArcGISRuntime::SpatialReference& spatialReference);
   void setPointToConvert(const Esri::ArcGISRuntime::Point& point);

--- a/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionOptions.h
+++ b/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionOptions.h
@@ -75,7 +75,7 @@ signals:
 
 public:
   CoordinateConversionOptions(QObject* parent = nullptr);
-  ~CoordinateConversionOptions();
+  ~CoordinateConversionOptions() override;
 
   QString name() const;
   void setName(const QString& name);

--- a/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionResults.h
+++ b/Plugin/CppApi/include/CoordinateConversion/CoordinateConversionResults.h
@@ -35,11 +35,11 @@ namespace Toolkit
 class Result
 {
 public:
- Result(const QString& name, const QString& notation, int type);
- ~Result() = default;
- QString m_name;
- QString m_notation;
- int m_type; // CoordinateConversionOptions::CoordinateType as int
+  Result(const QString& name, const QString& notation, int type);
+  ~Result() = default;
+  QString m_name;
+  QString m_notation;
+  int m_type = 0; // CoordinateConversionOptions::CoordinateType as int
 };
 
 class TOOLKIT_EXPORT CoordinateConversionResults : public QAbstractListModel
@@ -56,7 +56,7 @@ public:
 
 public:
   explicit CoordinateConversionResults(QObject* parent = nullptr);
-  ~CoordinateConversionResults();
+  ~CoordinateConversionResults() override;
 
   Qt::ItemFlags flags(const QModelIndex& index) const override;
 

--- a/Plugin/CppApi/include/TimeSliderController.h
+++ b/Plugin/CppApi/include/TimeSliderController.h
@@ -64,7 +64,7 @@ signals:
 
 public:
   TimeSliderController(QObject* parent = nullptr);
-  ~TimeSliderController();
+  ~TimeSliderController() override;
 
   QString toolName() const override;
 

--- a/Plugin/CppApi/include/ToolManager.h
+++ b/Plugin/CppApi/include/ToolManager.h
@@ -42,7 +42,7 @@ public:
 
   static ToolManager& instance(); // singleton
 
-  ~ToolManager();
+  ~ToolManager() override;
 
   void addTool(AbstractTool* tool);
 

--- a/Plugin/CppApi/include/ToolResourceProvider.h
+++ b/Plugin/CppApi/include/ToolResourceProvider.h
@@ -50,7 +50,7 @@ public:
 
   static ToolResourceProvider* instance();
 
-  ~ToolResourceProvider();
+  ~ToolResourceProvider() override;
 
   Map* map() const;
   void setMap(Map* newMap);


### PR DESCRIPTION
@JamesMBallard please review/merge.

- Add `override` when necessary.
- changes `Q_DECL_OVERRIDE` to `override` for consistency with the APIs.
- some code clean up (indentation, consistency)

Build tested on Mac.