### PR TITLE
Revert "Merge pull request #359 from Esri/james/macOS_openGL"

### DIFF
--- a/Examples/AR/CppArExample/main.cpp
+++ b/Examples/AR/CppArExample/main.cpp
@@ -65,12 +65,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);

--- a/Examples/AR/QmlArExample/main.cpp
+++ b/Examples/AR/QmlArExample/main.cpp
@@ -69,12 +69,6 @@ int main(int argc, char *argv[])
   QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
   fmt.setVersion(3, 2);
   QSurfaceFormat::setDefaultFormat(fmt);
-#elif defined(Q_OS_MACOS)
-  // macOS requires 4.1 OpenGL Context
-  QSurfaceFormat fmt = QSurfaceFormat::defaultFormat();
-  fmt.setProfile(QSurfaceFormat::OpenGLContextProfile::CoreProfile);
-  fmt.setVersion(4, 1);
-  QSurfaceFormat::setDefaultFormat(fmt);
 #endif
 
   QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);


### PR DESCRIPTION
This reverts commit e57c20403981d6b8ba5290e496c1d484d1fd6420, reversing
changes made to c84f6d8f7d20f6f05aceaf485fd0244a3e57d248.

@GuillaumeBelz please review. This reverts the previous changes to require OpenGL 4.1 on macOS.