### PR TITLE
Update wildcarding for Qt 5.15.0

### DIFF
--- a/toolkit.pro
+++ b/toolkit.pro
@@ -26,8 +26,8 @@ OTHER_FILES += \
     README.md \
     .gitattributes \
     .gitignore \
-    Import/*.qmlproject \
-    Examples/*.qmlproject \
+    $$files(Import/*.qmlproject) \
+    $$files(Examples/*.qmlproject) \
     Plugin/*
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Toolkit update for 5.15.0 wildcarding, only uses it in the one file.