### PR TITLE
selectByMouse set to true for TextFields.

### DIFF
--- a/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Controls/CppApi/CoordinateConversion.qml
@@ -280,6 +280,7 @@ Item {
             coordinateConvController.convertNotation(text);
             editCoordinateButton.checked = false;
         }
+        selectByMouse: true
     }
 
     Button {

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/ClientCertificateView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/ClientCertificateView.qml
@@ -380,6 +380,7 @@ Rectangle {
                 width: parent.width
                 placeholderText: qsTr("password")
                 echoMode: TextInput.Password
+                selectByMouse: true
             }
 
             Row {

--- a/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/UserCredentialsView.qml
+++ b/Import/Esri/ArcGISRuntime/Toolkit/Dialogs/UserCredentialsView.qml
@@ -197,6 +197,7 @@ Rectangle {
                 placeholderText: qsTr("username")
                 placeholderTextColor: "darkgray"
                 color: "black"
+                selectByMouse: true
             }
 
             TextField {
@@ -208,6 +209,7 @@ Rectangle {
                 placeholderTextColor: "darkgray"
                 echoMode: TextInput.Password
                 color: "black"
+                selectByMouse: true
             }
 
             Button {


### PR DESCRIPTION
@ldanzinger ready for review. Thanks!

Enabling select by mouse for text fields in the toolkit.