### PR TITLE
Add font to title and attachment headers

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -135,6 +135,7 @@ Control {
                 textFormat: Text.StyledText
                 text: `<h2>${controller.title}</h2>`
                 color: palette.text
+                font: popupView.font
             }
 
             // Field names
@@ -155,6 +156,7 @@ Control {
                 textFormat: Text.StyledText
                 text: controller.attachmentCount > 0 ? "<h2>Attachments</h2>" : ""
                 color: palette.text
+                font: popupView.font
             }
 
             // Attachment names


### PR DESCRIPTION
This PR sets the `font` property of the title and attachment headers of a PopupView. Previously, updating `popupView.font` would only update the font of the "Close" button. 