### PR TITLE
reworking toolkit doc for 100.10

### DIFF
--- a/augmentedreality/Common/qml/CalibrationView.qml
+++ b/augmentedreality/Common/qml/CalibrationView.qml
@@ -77,6 +77,13 @@ Item {
       \qmlsignal triggered(double latitude, double longitude, double altitude, double heading)
       \brief Sends the updated values for location and heading.
 
+      \list
+        \li \a latitude - The latitude (y) of the location.
+        \li \a longitude - The longitude (x) of the location.
+        \li \a altitude - The altitude (z) of the location.
+        \li \a heading - The heading or direction of the location.
+      \endlist
+
       This signal is emitted every time the timer is triggered.
      */
     signal triggered(double latitude, double longitude, double altitude, double heading);

--- a/augmentedreality/Common/source/LocationDataSource.cpp
+++ b/augmentedreality/Common/source/LocationDataSource.cpp
@@ -327,36 +327,36 @@ void LocationDataSource::updateObjectsAndConnections()
 // signals
 
 /*!
-  \fn void LocationDataSource::headingChanged(double heading);
+  \fn void Esri::ArcGISRuntime::Toolkit::LocationDataSource::headingChanged(double heading);
   \brief Signal emitted when the heading value changes.
  */
 
 /*!
-  \fn void LocationDataSource::isStartedChanged();
+  \fn void Esri::ArcGISRuntime::Toolkit::LocationDataSource::isStartedChanged();
   \brief Signal emitted when the \l isStarted property changes.
  */
 
 /*!
-  \fn void LocationDataSource::locationChanged(double latitude, double longitude, double altitude);
+  \fn void Esri::ArcGISRuntime::Toolkit::LocationDataSource::locationChanged(double latitude, double longitude, double altitude);
   \brief Signal emitted when the location values change.
  */
 
 /*!
-  \fn void LocationDataSource::geoPositionSourceChanged();
+  \fn void Esri::ArcGISRuntime::Toolkit::LocationDataSource::geoPositionSourceChanged();
   \brief Signal emitted when the \l geoPositionSource property changes.
  */
 
 /*!
-  \fn void LocationDataSource::compassChanged();
+  \fn void Esri::ArcGISRuntime::Toolkit::LocationDataSource::compassChanged();
   \brief Signal emitted when the \l compass property changes.
  */
 
 /*!
-  \fn void LocationDataSource::sensorStatusChanged();
+  \fn void Esri::ArcGISRuntime::Toolkit::LocationDataSource::sensorStatusChanged();
   \brief Signal emitted when the \l sensorStatus property changes.
  */
 
 /*!
-  \fn void LocationDataSource::locationTrackingModeChanged();
+  \fn void Esri::ArcGISRuntime::Toolkit::LocationDataSource::locationTrackingModeChanged();
   \brief Signal emitted when the \l locationTrackingMode property changes.
  */

--- a/augmentedreality/QmlApi/qml/ArcGISArView.qml
+++ b/augmentedreality/QmlApi/qml/ArcGISArView.qml
@@ -143,7 +143,7 @@ ArcGISArViewInternal {
     }
 
     /*!
-        \brief Gets the location in the real world space corresponding to the screen point \a screenPoint.
+        \brief Gets the real world location to the corresponding \a x and \a y screen coordinates.
      */
     function screenToLocation(x, y) {
         const hitTest = root.hitTest(x, y);

--- a/augmentedreality/QmlApi/source/QmlArcGISArView.cpp
+++ b/augmentedreality/QmlApi/source/QmlArcGISArView.cpp
@@ -27,7 +27,7 @@ using namespace Esri::ArcGISRuntime::Toolkit;
   \ingroup ArcGISQtToolkit
   \ingroup ArcGISQtToolkitQmlApi
   \inmodule ArcGISQtToolkit
-  \since Esri::ArcGISRuntime 100.6
+  \since Esri::ArcGISArToolkit  100.6
   \brief A scene view for displaying ARKit/ARCore features on mobile devices
    using the QML API.
 

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/AuthenticationController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/AuthenticationController.cpp
@@ -28,6 +28,7 @@ namespace Toolkit
 /*!
  \class Esri::ArcGISRuntime::Toolkit::AuthenticationController
  \inmodule EsriArcGISRuntimeToolkit
+ \ingroup ArcGISQtToolkitUiCppControllers
  \brief In MVC architecture, this is the controller for the corresponding
  AuthenticationView.
 

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/CoordinateConversionController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/CoordinateConversionController.cpp
@@ -40,6 +40,7 @@ constexpr double DEFAULT_ZOOM_TO_DISTANCE = 1500.0;
 
 /*!  
   \class Esri::ArcGISRuntime::Toolkit::CoordinateConversionController
+  \ingroup ArcGISQtToolkitUiCppControllers
   \inmodule EsriArcGISRuntimeToolkit
 
   \brief In MVC architecture, this is the controller for the corresponding

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/CoordinateConversionOption.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/CoordinateConversionOption.cpp
@@ -29,6 +29,7 @@ namespace Toolkit
 /*!
   \class Esri::ArcGISRuntime::Toolkit::CoordinateConversionOption
   \inmodule ArcGISRuntimeToolkit
+  \ingroup ArcGISQtToolkitUiCppControllers
   \brief a \c CoordinateConversionOption is a collection of properties that
   dictates how a \c Point should be converted to and from a string.
   

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/NorthArrowController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/NorthArrowController.cpp
@@ -30,6 +30,7 @@ namespace Toolkit
 /*!
   \class Esri::ArcGISRuntime::Toolkit::NorthArrowController
   \inmodule EsriArcGISRuntimeToolkit
+  \ingroup ArcGISQtToolkitUiCppControllers
   \brief In MVC architecture, this is the controller for the corresponding
   \c NorthArrow view.
   

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/PopupViewController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/PopupViewController.cpp
@@ -25,6 +25,7 @@ namespace Toolkit
 /*!
   \class Esri::ArcGISRuntime::Toolkit::PopupViewController
   \inmodule ArcGISRuntimeToolkit
+  \ingroup ArcGISQtToolkitUiCppControllers
   \brief In MVC architecture, this is the controller for the corresponding
   \c PopupView.
   

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/TimeSliderController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/TimeSliderController.cpp
@@ -142,6 +142,7 @@ namespace
 /*!
   \class Esri::ArcGISRuntime::Toolkit::TimeSliderController
   \inmodule ArcGISRuntimeToolkit
+  \ingroup ArcGISQtToolkitUiCppControllers
   \brief In MVC architecture, this is the controller for the corresponding
   \c TimeSlider.
   

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/AuthenticationView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/AuthenticationView.qml
@@ -22,7 +22,8 @@ import QtQuick.Controls 2.12
 /*!
   \qmltype AuthenticationView
   \inqmlmodule Esri.ArcGISRuntime.Toolkit
-  \since Esri.ArcGISRutime 100.9
+  \ingroup ArcGISQtToolkitUiQmlViews
+  \since Esri.ArcGISRutime 100.10
   \brief A view for handling authentication challenges and automatically 
   launching the appropriate UI for each type of authentication.
     

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
@@ -23,8 +23,9 @@ import "LeaderPosition.js" as Enums
     \qmltype Callout
     \ingroup ArcGISQtToolkit
     \ingroup ArcGISQtToolkitQmlApi
+    \ingroup ArcGISQtToolkitUiQmlViews
     \inqmlmodule Esri.ArcGISRuntime.Toolkit.Controls
-    \since Esri.ArcGISRutime 100.9
+    \since Esri.ArcGISRutime 100.10
     \brief A view for displaying information at a geographic location on a Map.
 
      A Callout can be displayed for several different scenarios:

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/AuthenticationController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/AuthenticationController.qml
@@ -20,7 +20,8 @@ import Esri.ArcGISRuntime 100.8
 /*!
   \qmltype AuthenticationController
   \inqmlmodule Esri.ArcGISRuntime.Toolkit
-  \since Esri.ArcGISRutime 100.9
+  \since Esri.ArcGISRutime 100.10
+  \ingroup ArcGISQtToolkitUiQmlControllers
   \brief In MVC architecture, this is the controller for the corresponding
   AuthenticationView.  
   

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/CoordinateConversionController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/CoordinateConversionController.qml
@@ -19,7 +19,8 @@ import Esri.ArcGISRuntime 100.8
 /*!
    \qmltype CoordinateConversionController
    \inqmlmodule Esri.ArcGISRuntime.Toolkit
-   \since Esri.ArcGISRutime 100.8
+   \since Esri.ArcGISRutime 100.10
+   \ingroup ArcGISQtToolkitUiQmlControllers
    \brief In MVC architecture, this is the controller for the 
    CoordinateConversion view.
  */

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/CoordinateConversionOption.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/CoordinateConversionOption.qml
@@ -20,7 +20,8 @@ import Esri.ArcGISRuntime 100.8
 /*!
    \qmltype CoordinateConversionOption
    \inqmlmodule Esri.ArcGISRuntime.Toolkit
-   \since Esri.ArcGISRutime 100.8
+   \since Esri.ArcGISRutime 100.10
+   \ingroup ArcGISQtToolkitUiQmlControllers
    \brief a CoordinateConversionOption is a collection of properties that
    dictates how a Point should be converted to and from a string.
    

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/CoordinateConversionResult.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/CoordinateConversionResult.qml
@@ -18,7 +18,8 @@ import QtQml 2.12
 /*!
    \qmltype CoordinateConversionResult
    \inqmlmodule Esri.ArcGISRuntime.Toolkit
-   \since Esri.ArcGISRutime 100.8
+   \ingroup ArcGISQtToolkitUiQmlControllers
+   \since Esri.ArcGISRutime 100.10
    \brief a CoordinateConversionResult stores the textual representation of a
    a point converted to a string using the formatting given in a 
    CoordinateConversionOption.

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/NorthArrowController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/NorthArrowController.qml
@@ -18,7 +18,8 @@ import QtQml 2.12
 /*!
    \qmltype NorthArrowController
    \inqmlmodule Esri.ArcGISRuntime.Toolkit
-   \since Esri.ArcGISRutime 100.8
+   \since Esri.ArcGISRutime 100.10
+   \ingroup ArcGISQtToolkitUiQmlControllers
    \brief In MVC architecture, this is the controller for the corresponding
    NorthArrow view.
    

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/PopupViewController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/PopupViewController.qml
@@ -19,7 +19,8 @@ import QtQml 2.12
 /*!
    \qmltype PopupViewController
    \inqmlmodule Esri.ArcGISRuntime.Toolkit
-   \since Esri.ArcGISRuntime 100.8
+   \since Esri.ArcGISRuntime 100.10
+   \ingroup ArcGISQtToolkitUiQmlControllers
    \brief In MVC architecture, this is the controller for the corresponding
    PopupView.
    

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/TimeSliderController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/TimeSliderController.qml
@@ -21,7 +21,8 @@ import Esri.ArcGISRuntime 100.9
 /*!
    \qmltype TimeSliderController
    \inqmlmodule Esri.ArcGISRuntime.Toolkit
-   \since Esri.ArcGISRuntime 100.9
+   \since Esri.ArcGISRuntime 100.10
+   \ingroup ArcGISQtToolkitUiQmlControllers
    \brief In MVC architecture, this is the controller for the corresponding
    TimeSlider.
    

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/CoordinateConversion.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/CoordinateConversion.qml
@@ -23,7 +23,8 @@ import QtQuick.Layouts 1.12
 /*!
  \qmltype CoordinateConversion
  \inqmlmodule Esri.ArcGISRuntime.Toolkit
- \since Esri.ArcGISRutime 100.8
+ \ingroup ArcGISQtToolkitUiQmlViews
+ \since Esri.ArcGISRutime 100.10
  \brief The user interface for the coordinate conversion tool.
 
  This tool allows a user to select a point on the map or to enter a point by

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/FlashImage.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/FlashImage.qml
@@ -19,7 +19,7 @@ import QtQuick 2.12
  * \internal
  * \qmltype FlashImage
  * \inqmlmodule Esri.ArcGISRuntime.Toolkit
- * \since Esri.ArcGISRutime 100.8
+ * \since Esri.ArcGISRutime 100.10
  * \brief a FlashImage just exists to display a flashing blue dot on a map
  * for the CoordinateConversion tool, then delete itself after its animation
  * is complete.

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
@@ -20,7 +20,8 @@ import QtQuick 2.12
 /*!
    \qmltype NorthArrow
    \inqmlmodule Esri.ArcGISRuntime.Toolkit
-   \since Esri.ArcGISRutime 100.8
+   \ingroup ArcGISQtToolkitUiQmlViews
+   \since Esri.ArcGISRutime 100.10
    \brief The NorthArrow displays a compass overlaid on the GeoView, with the
    compass heading matching the current rotation of the MapView, or Camera
    heading of the SceneView. 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
@@ -22,7 +22,8 @@ import QtQuick.Layouts 1.12
    \qmltype PopupStackView
    \ingroup ArcGISQtToolkit
    \inqmlmodule Esri.ArcGISRuntime.Toolkit
-   \since Esri.ArcGISRuntime 100.8
+   \ingroup ArcGISQtToolkitUiQmlViews
+   \since Esri.ArcGISRuntime 100.10
    \brief A view for displaying and editing information of GeoElements,
    including Features and Graphics.
    

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -25,8 +25,9 @@ import QtQuick.Layouts 1.3
 /*!
    \qmltype PopupView
    \ingroup ArcGISQtToolkit
+   \ingroup ArcGISQtToolkitUiQmlViews
    \inqmlmodule Esri.ArcGISRuntime.Toolkit
-   \since Esri.ArcGISRuntime 100.8
+   \since Esri.ArcGISRuntime 100.10
    \brief A view for displaying and editing information about a feature.
   
    A PopupView can be used to display information for any type that

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
@@ -23,7 +23,8 @@ import QtQuick.Layouts 1.12
 /*!
     \qmltype TimeSlider
     \inqmlmodule Esri.ArcGISRuntime.Toolkit
-    \since Esri.ArcGISRutime 100.9
+    \ingroup ArcGISQtToolkitUiQmlViews
+    \since Esri.ArcGISRutime 100.10
     \brief The slider provides a user interface for manually setting or animating
     changes to the current time extent of the \c GeoView.
     

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/CoordinateConversion.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/CoordinateConversion.cpp
@@ -48,6 +48,7 @@ namespace Toolkit
 /*!
   \class Esri::ArcGISRuntime::Toolkit::CoordinateConversion
   \inmodule EsriArcGISRuntimeToolkit
+  \ingroup ArcGISQtToolkitUiCppWidgetsViews
   \brief The user interface for the coordinate conversion tool.
   This tool allows a user to select a point on the map or to enter a point by
   text entry.

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/NorthArrow.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/NorthArrow.cpp
@@ -35,6 +35,7 @@ namespace Toolkit
 /*!
   \class Esri::ArcGISRuntime::Toolkit::NorthArrow
   \inmodule EsriArcGISRuntimeToolkit
+  \ingroup ArcGISQtToolkitUiCppWidgetsViews
   \brief The \c NorthArrow displays a compass overlaid on the \c GeoView, with 
   the compass heading matching the current rotation of the \c MapView, or 
   \c Camera heading of the \c SceneView. 


### PR DESCRIPTION
@JamesMBallard please review 

This is for the landing page redesign. Here is example output html. Also fixing a couple of small doc build warnings. There are still many more unrelated to this change.

[api-reference.zip](https://github.com/Esri/arcgis-runtime-toolkit-qt/files/5576328/api-reference.zip)
