### PR TITLE
moving onAccepted from DialogButtonBox to the Dialog itself

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/UserCredentialsView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/UserCredentialsView.qml
@@ -46,15 +46,15 @@ Dialog {
             text: qsTr("Continue")
             DialogButtonBox.buttonRole: DialogButtonBox.AcceptRole
         }
+    }
 
-        onAccepted: {
-            controller.continueWithUsernamePassword(usernameTextField.text,
-                                                    passwordTextField.text);
-        }
+    onAccepted: {
+        controller.continueWithUsernamePassword(usernameTextField.text,
+                                                passwordTextField.text);
+    }
 
-        onRejected: {
-            controller.cancel();
-        }
+    onRejected: {
+        controller.cancel();
     }
 
     ColumnLayout {


### PR DESCRIPTION
@ldanzinger or @anmacdonald This is ready for review. Please feel free to merge if these changes are approved.

This allows for hitting enter/return to emit the accept() signal to submit the credential information provided in the `UserCredentialView.qml`.