### PR TITLE
fixing up qml client certificate view

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/ClientCertificateView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/ClientCertificateView.qml
@@ -118,7 +118,7 @@ Dialog {
     Connections {
         target: controller
 
-        onClientCertificatePasswordRequired: {
+        function onClientCertificatePasswordRequired(certificate) {
             const dialog = passwordDialog.createObject(
                              clientCertificateView.parent, { certificate: certificate});
             dialog.open();

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/AuthenticationController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/AuthenticationController.qml
@@ -81,7 +81,7 @@ QtObject {
     property int currentChallengeFailureCount: internal.currentChallenge ? internal.currentChallenge.failureCount : 0;
     
     /*!
-    \qmlproperty int clientCertificateInfos
+    \qmlproperty list<string> clientCertificateInfos
     \brief The list of ClientCertificateInfo strings currently held by the
     AuthenticationManager.
     */
@@ -141,7 +141,7 @@ QtObject {
   
                 internal.currentChallenge = challenge;
             }
-            function onClientCertificatePasswordRequired() {
+            function onClientCertificatePasswordRequired(certificate) {
                 authenticationController.clientCertificatePasswordRequired(certificate);
             }
         }


### PR DESCRIPTION
@JamesMBallard please review. I was testing PKI with the new service but got hung up with some console errors - with the new Connections syntax requiring a function, parameters need to be specified, or you'll get a runtime error that certificate is not defined. Also updating another function to use new syntax and updating doc error