### PR TITLE
Fixing control issues in authviews.

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/ClientCertificateView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/ClientCertificateView.qml
@@ -35,7 +35,6 @@ Dialog {
 
     footer: DialogButtonBox {
         Button {
-            id: bBox
             text: qsTr("Skip")
             DialogButtonBox.buttonRole: DialogButtonBox.RejectRole
         }

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/AuthenticationController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/AuthenticationController.qml
@@ -105,28 +105,38 @@ QtObject {
     }
   
     function continueWithUsernamePassword(...args) {
-        internal.currentChallenge.continueWithUsernamePassword(...args);
-        internal.currentChallenge = null;
+        if (internal.currentChallenge) {
+            internal.currentChallenge.continueWithUsernamePassword(...args);
+            internal.currentChallenge = null;
+        }
     }
   
     function continueWithOAuthAuthorizationCode(...args) {
-        internal.currentChallenge.continueWithOAuthAuthorizationCode(...args);
-        internal.currentChallenge = null;
+        if (internal.currentChallenge) {
+            internal.currentChallenge.continueWithOAuthAuthorizationCode(...args);
+            internal.currentChallenge = null;
+        }
     }
   
     function continueWithClientCertificate(...args) {
-        internal.currentChallenge.continueWithClientCertificate(...args);
-        internal.currentChallenge = null;
+        if (internal.currentChallenge) {
+            internal.currentChallenge.continueWithClientCertificate(...args);
+            internal.currentChallenge = null;
+        }
     }
   
     function continueWithSslHandshake(...args) {
-        internal.currentChallenge.continueWithSslHandshake(...args);
-        internal.currentChallenge = null;
+        if (internal.currentChallenge) {
+            internal.currentChallenge.continueWithSslHandshake(...args);
+            internal.currentChallenge = null;
+        }
     }
   
     function cancel(...args) {
-        internal.currentChallenge.cancel(...args);
-        internal.currentChallenge = null;
+        if (internal.currentChallenge) {
+            internal.currentChallenge.cancel(...args);
+            internal.currentChallenge = null;
+        }
     }
     
     property QtObject internal: QtObject {

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/OAuth2View.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/OAuth2View.qml
@@ -64,7 +64,7 @@ Dialog {
                 controller.continueWithOAuthAuthorizationCode(authCode);
                 oAuthView.accept();
             } else if (title.indexOf("Denied error=") > -1) {
-                oAuthView.reject();
+                controller.cancel();
             }
         }
     }

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/OAuth2View.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/OAuth2View.qml
@@ -62,7 +62,6 @@ Dialog {
             if (title.indexOf("SUCCESS code=") > -1) {
                 var authCode = title.replace("SUCCESS code=", "");
                 controller.continueWithOAuthAuthorizationCode(authCode);
-                oAuthView.accept();
             } else if (title.indexOf("Denied error=") > -1) {
                 controller.cancel();
             }

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/UserCredentialsView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/UserCredentialsView.qml
@@ -37,7 +37,6 @@ Dialog {
 
     footer: DialogButtonBox {
         Button {
-            id: bBox
             text: qsTr("Skip")
             DialogButtonBox.buttonRole: DialogButtonBox.RejectRole
         }
@@ -46,15 +45,14 @@ Dialog {
             text: qsTr("Continue")
             DialogButtonBox.buttonRole: DialogButtonBox.AcceptRole
         }
-    }
 
-    onAccepted: {
-        controller.continueWithUsernamePassword(usernameTextField.text,
-                                                passwordTextField.text);
-    }
+        onAccepted: {
+            acceptWithCurrentUsernameAndPassword();
+        }
 
-    onRejected: {
-        controller.cancel();
+        onRejected: {
+            controller.cancel();
+        }
     }
 
     ColumnLayout {
@@ -91,7 +89,7 @@ Dialog {
         TextField {
             id: usernameTextField
             placeholderText: qsTr("username")
-            onAccepted: userCredentialsView.accept();
+            onAccepted: acceptWithCurrentUsernameAndPassword()
             Layout.fillWidth: true
             Layout.margins: 5
         }
@@ -99,10 +97,20 @@ Dialog {
         TextField {
             id: passwordTextField
             placeholderText: qsTr("password")
-            onAccepted: userCredentialsView.accept();
+            onAccepted: acceptWithCurrentUsernameAndPassword()
             echoMode: TextInput.Password
             Layout.fillWidth: true
             Layout.margins: 5
         }
+    }
+
+    /*!
+     \internal
+     \brief Attempts to apply the current username and password to
+     the token.
+     */
+    function acceptWithCurrentUsernameAndPassword() {
+        controller.continueWithUsernamePassword(usernameTextField.text,
+                                                passwordTextField.text);
     }
 }


### PR DESCRIPTION
Flushing out cancel bugs and some recursive calls issues that appeared.

The workflow should always be:
* The specific pages accept/reject using the controller.
* The page is deleted via the controller's clearing of the current credential. The page does not try to accept/reject itself.

Added some extra gaurds to AuthenticationController.qml  that were missing.