### PR TITLE
workaround for 5.15.1 regression

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
@@ -468,10 +468,11 @@ Item {
                         top: parent.top
                     }
                     height: calloutHeight
-                    width: calloutWidth
                     columns: 3
                     rows: 2
                     columnSpacing: 7
+
+                    onWidthChanged: preCalculateWidthAndHeight()
 
                     Rectangle {
                         id: imageRect


### PR DESCRIPTION
@JamesMBallard please review/merge

The issue is that whenever showCallout is called, precalculateWidthAndHeight is called. precalculateWidthAndHeight gets the grid layout's width and figures out how big the frame should be (depending on the content, accessory button, icon, etc). However, for some reason, the timing order has changed at 5.15.1, and the grid layout's width isn't updated until after precalculateWidthAndHeight executes, which means that the first time precalculate runs, it is calculating based on the wrong dimensions. This causes the frame to display incorrectly, usually too small. The previous fix fixed the sample because it just set the initial width as something large enough that it happened to display as desired. However, the test app tests many different scenarios, getting way larger and way smaller, modifying leader width, etc. This turned up more issues, and the previous fix was not viable. This new workaround just calls precalculate once the width changes, which ensures it is recalculated again if the width changes after we expected it to. 

This fix fixes the sample and the tests cases in the test app. There is no noticeable performance difference. 

FYI - Previously, I attempted to decouple this from our API and test app to send to Qt, but couldn't get it to reproduce outside of the environment.