### PR TITLE
Remove the Qt version check.

### DIFF
--- a/augmentedreality/Examples/CppArExample/CppArExample.pro
+++ b/augmentedreality/Examples/CppArExample/CppArExample.pro
@@ -17,18 +17,9 @@
 TEMPLATE = app
 
 QT += core gui opengl network positioning sensors qml quick multimedia
-CONFIG += c++11
+CONFIG += c++14
 
 TARGET = CppArExample
-
-equals(QT_MAJOR_VERSION, 5) {
-    lessThan(QT_MINOR_VERSION, 12) {
-        error("$$TARGET requires Qt 5.15.1")
-    }
-    equals(QT_MINOR_VERSION, 12) : lessThan(QT_PATCH_VERSION, 6) {
-        error("$$TARGET requires Qt 5.15.1")
-    }
-}
 
 ARCGIS_RUNTIME_VERSION = 100.11
 include($$PWD/arcgisruntime.pri)

--- a/augmentedreality/Examples/QmlArExample/QmlArExample.pro
+++ b/augmentedreality/Examples/QmlArExample/QmlArExample.pro
@@ -20,7 +20,7 @@ mac {
 
 #-------------------------------------------------------------------------------
 
-CONFIG += c++11
+CONFIG += c++14
 
 QT += core gui opengl network positioning sensors qml quick
 
@@ -29,17 +29,6 @@ include($$PWD/arcgisruntime.pri)
 
 TEMPLATE = app
 TARGET = QmlArExample
-
-equals(QT_MAJOR_VERSION, 5) {
-    lessThan(QT_MINOR_VERSION, 15) {
-        error("$$TARGET requires Qt 5.15.1")
-    }
-    equals(QT_MINOR_VERSION, 15) : lessThan(QT_PATCH_VERSION, 1) {
-        error("$$TARGET requires Qt 5.15.1")
-    }
-}
-
-#-------------------------------------------------------------------------------
 
 HEADERS += \
     AppInfo.h


### PR DESCRIPTION
@jared-2016 please review.

Instead of upgrading the version check, I'm removing it. We don't have this in any of our samples and this keeps ongoing maintenance simple. I also upgraded the C++ version to C++14, our latest.