### PR TITLE
Revert "workaround for 5.15.1 regression"

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
@@ -468,11 +468,10 @@ Item {
                         top: parent.top
                     }
                     height: calloutHeight
+                    width: calloutWidth
                     columns: 3
                     rows: 2
                     columnSpacing: 7
-
-                    onWidthChanged: preCalculateWidthAndHeight()
 
                     Rectangle {
                         id: imageRect


### PR DESCRIPTION
Reverts Esri/arcgis-runtime-toolkit-qt#408

@JamesMBallard please review/merge

This was a workaround, and now the behavior seems to be fixed in Qt 5.15.2+

I tested with the current v.next and ran into the issue reported by the release team, and with this change, the sample and test app works as expected