### PR TITLE
Widget-based AuthenticationView

### DIFF
--- a/uitools/toolkitwidgets.pri
+++ b/uitools/toolkitwidgets.pri
@@ -21,14 +21,32 @@ WIDGETPATH = $$PWD/widgets/Esri/ArcGISRuntime/Toolkit
 
 INCLUDEPATH += $$PWD/widgets $$WIDGETPATH
 
-HEADERS += $$WIDGETPATH/CoordinateConversion.h \
+HEADERS += $$WIDGETPATH/AuthenticationView.h \
+           $$WIDGETPATH/CoordinateConversion.h \
+           $$WIDGETPATH/Internal/ClientCertificatePasswordDialog.h \
+           $$WIDGETPATH/Internal/ClientCertificateView.h \
            $$WIDGETPATH/Internal/CoordinateEditDelegate.h \
            $$WIDGETPATH/Internal/Flash.h \
+           $$WIDGETPATH/Internal/OAuth2View.h \
+           $$WIDGETPATH/Internal/SslHandshakeView.h \
+           $$WIDGETPATH/Internal/UserCredentialView.h \
            $$WIDGETPATH/NorthArrow.h
 
-SOURCES += $$WIDGETPATH/CoordinateConversion.cpp \
+SOURCES += $$WIDGETPATH/AuthenticationView.cpp \
+           $$WIDGETPATH/CoordinateConversion.cpp \
+           $$WIDGETPATH/Internal/ClientCertificatePasswordDialog.cpp \
+           $$WIDGETPATH/Internal/ClientCertificateView.cpp \
            $$WIDGETPATH/Internal/CoordinateEditDelegate.cpp \ 
            $$WIDGETPATH/Internal/Flash.cpp \
+           $$WIDGETPATH/Internal/OAuth2View.cpp \
+           $$WIDGETPATH/Internal/SslHandshakeView.cpp \
+           $$WIDGETPATH/Internal/UserCredentialView.cpp \
            $$WIDGETPATH/NorthArrow.cpp
 
-FORMS += $$WIDGETPATH/CoordinateConversion.ui
+FORMS += $$WIDGETPATH/AuthenticationView.ui \
+         $$WIDGETPATH/Internal/ClientCertificatePasswordDialog.ui \
+         $$WIDGETPATH/Internal/ClientCertificateView.ui \
+         $$WIDGETPATH/Internal/OAuth2View.ui \
+         $$WIDGETPATH/Internal/SslHandshakeView.ui \
+         $$WIDGETPATH/Internal/UserCredentialView.ui \
+         $$WIDGETPATH/CoordinateConversion.ui

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/AuthenticationView.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/AuthenticationView.cpp
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#include "AuthenticationView.h"
+#include "ui_AuthenticationView.h"
+
+// Toolkit Controller headers
+#include "AuthenticationController.h"
+
+// Toolkit widget headers
+#include "Internal/UserCredentialView.h"
+#include "Internal/OAuth2View.h"
+#include "Internal/ClientCertificateView.h"
+#include "Internal/SslHandshakeView.h"
+
+namespace Esri
+{
+namespace ArcGISRuntime
+{
+namespace Toolkit
+{
+
+namespace 
+{
+  QWidget* createWidgetView(AuthenticationController* controller, AuthenticationView* view)
+  {
+    Q_ASSERT(controller);
+    auto challengeType = static_cast<AuthenticationChallengeType>(controller->currentChallengeType());
+
+    if (challengeType == AuthenticationChallengeType::UsernamePassword) {
+      // ArcGIS token, HTTP Basic/Digest, IWA
+      return new UserCredentialView(controller, view);
+    } 
+    else if (challengeType == AuthenticationChallengeType::OAuth)
+    {
+      // OAuth 2
+      return new OAuth2View(controller, view);
+    }
+    else if (challengeType == AuthenticationChallengeType::ClientCertificate)
+    {
+      // Client Certificate
+      return new ClientCertificateView(controller, view);
+    }
+    else if (challengeType == AuthenticationChallengeType::SslHandshake) {
+      // SSL Handshake - Self-signed certificate
+      return new SslHandshakeView(controller, view);
+    }
+    else
+    {
+      // Load nothing, challenge not understood.
+      return nullptr;
+    }
+  }
+}
+
+/*!
+  \class Esri::ArcGISRuntime::Toolkit::AuthenticationView
+  \inmodule EsriArcGISRuntimeToolkit
+  \ingroup ArcGISQtToolkitUiCppWidgetsViews
+  \since Esri.ArcGISRutime 100.12
+  \brief A view for handling authentication challenges and automatically 
+  launching the appropriate UI for each type of authentication.
+    
+  Declare an AuthenticationView. The AuthenticationView 
+  will then be connected to all authentication challenges, and will
+  automatically launch the appropriate view for the type of
+  challenge. Supported security formats include:
+
+  \list
+    \li ArcGIS Token (user credentials)
+    \li HTTP Basic (user credentials)
+    \li HTTP Digest (user credentials)
+    \li IWA (user credentials)
+    \li OAuth 2.0 (OAuth2)
+    \li SAML (OAuth2)
+    \li PKI (client certificate)
+    \li SSL Handshake Warnings (ssl)
+  \endlist
+  
+  \note OAuth 2.0 uses QWebEngineView. To use OAuth you must add \c{QT += webenginewidgets}
+        to \c{qmake}.
+        See \l{https://doc.qt.io/qt-5/qwebengineview.html}{QWebEngineView}.
+ */
+
+/*!
+  \brief Constructor.
+  \list
+    \li \a parent Parent widget.
+  \endlist
+
+  Internally the view will create and maintain its own \l AuthenticationController.
+ */
+AuthenticationView::AuthenticationView(QWidget* parent) :
+  AuthenticationView(nullptr, parent)
+{
+  setController(new AuthenticationController(this));
+}
+
+/*!
+  \brief Constructor.
+  \list
+    \li \a controller AuthenticationController which will drive the view.
+    \li \a parent Parent widget.
+  \endlist
+ */
+AuthenticationView::AuthenticationView(AuthenticationController* controller, QWidget* parent) :
+  QDialog(parent),
+  m_controller(controller),
+  m_ui(new Ui::AuthenticationView)
+{
+  m_ui->setupUi(this);
+  connect(this, &QDialog::rejected, this, [this] { m_controller ? m_controller->cancel() : void();});
+  setModal(true);
+}
+
+/*!
+  \brief Destructor.
+ */
+AuthenticationView::~AuthenticationView()
+{
+  delete m_ui;
+}
+
+/*!
+  \brief Returns the controller.
+ */
+AuthenticationController* AuthenticationView::controller() const
+{
+  return m_controller;
+}
+
+/*!
+  \brief Sets the controller.
+ */
+void AuthenticationView::setController(AuthenticationController* controller)
+{
+  if (controller != m_controller)
+  {
+    // Disconnect from everything.
+    if (m_controller)
+    {
+      disconnect(m_controller, nullptr, this, nullptr);
+      m_controller->cancel();
+    }
+    m_controller = controller;
+
+    connect(m_controller, &AuthenticationController::currentChallengeChanged, this, 
+            [this]{
+              auto view = createWidgetView(m_controller, this);
+              if (!view)
+              {
+                this->hide();
+                return;
+              }
+
+              // Delete view if the challenge changes during its lifetime.
+              connect(m_controller, &AuthenticationController::currentChallengeChanged, view, [view]() { view->deleteLater(); });
+
+              m_ui->viewContent->addWidget(view);
+
+              setWindowTitle(view->windowTitle());
+              connect(view, &QWidget::windowTitleChanged, this, [this](const QString& title) { setWindowTitle(title); });
+
+              this->show();
+            });
+  }
+  emit authenticationControllerChanged();
+}
+
+/*!
+  \fn void Esri::ArcGISRuntime::Toolkit::AuthenticationView::authenticationControllerChanged()
+  \brief Emitted when the controller used to drive the view changes.
+ */
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/AuthenticationView.h
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/AuthenticationView.h
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#ifndef ESRI_ARCGISRUNTIME_AUTHENTICATIONVIEW_H
+#define ESRI_ARCGISRUNTIME_AUTHENTICATIONVIEW_H
+
+#include <QDialog>
+
+namespace Ui
+{
+class AuthenticationView;
+}
+
+namespace Esri
+{
+namespace ArcGISRuntime
+{
+
+namespace Toolkit
+{
+
+class AuthenticationController;
+
+class AuthenticationView : public QDialog 
+{
+  Q_OBJECT
+public:
+  explicit AuthenticationView(AuthenticationController* controller, QWidget* parent = nullptr);
+  explicit AuthenticationView(QWidget* parent = nullptr);
+  ~AuthenticationView() override;
+
+  AuthenticationController* controller() const;
+  void setController(AuthenticationController* controller);
+
+signals:
+  void authenticationControllerChanged();
+
+private:
+  AuthenticationController* m_controller = nullptr;
+  Ui::AuthenticationView* m_ui = nullptr;
+};
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri
+
+#endif // ESRI_ARCGISRUNTIME_AUTHENTICATIONVIEW_H

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/AuthenticationView.ui
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/AuthenticationView.ui
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>AuthenticationView</class>
+ <widget class="QDialog" name="AuthenticationView">
+  <property name="windowModality">
+   <enum>Qt::ApplicationModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>396</width>
+    <height>249</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <property name="modal">
+   <bool>false</bool>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="viewContent"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificatePasswordDialog.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificatePasswordDialog.cpp
@@ -1,0 +1,62 @@
+ /*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#include "ClientCertificatePasswordDialog.h"
+#include "ui_ClientCertificatePasswordDialog.h"
+
+#include "AuthenticationController.h"
+
+namespace Esri
+{
+namespace ArcGISRuntime
+{
+namespace Toolkit
+{
+
+/*!
+  \brief Constructor.
+  \list
+    \li \a parent Parent widget.
+  \endlist
+ */
+ClientCertificatePasswordDialog::ClientCertificatePasswordDialog(QUrl certificateFile, AuthenticationController* controller, QWidget* parent) :
+  QDialog(parent),
+  m_certificateFile(std::move(certificateFile)),
+  m_controller(controller),
+  m_ui(new Ui::ClientCertificatePasswordDialog)
+{
+  m_ui->setupUi(this);
+  setAttribute(Qt::WA_DeleteOnClose);
+
+  m_ui->preamble->setText(
+    QString(tr("The client certificate file '%1' requires a password to open.")).arg(m_certificateFile.fileName()));
+
+  connect(this, &QDialog::accepted, this,
+          [this]
+          {
+            if (m_controller)
+              m_controller->addClientCertificate(m_certificateFile, m_ui->passwordEdit->text());
+          });
+}
+
+ClientCertificatePasswordDialog::~ClientCertificatePasswordDialog()
+{
+  delete m_ui;
+}
+
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificatePasswordDialog.h
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificatePasswordDialog.h
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#ifndef ESRI_ARCGISRUNTIME_CLIENTCERTIFICATEPASSWORDDIALOG_H
+#define ESRI_ARCGISRUNTIME_CLIENTCERTIFICATEPASSWORDDIALOG_H
+
+#include <QDialog>
+#include <QUrl>
+
+namespace Ui
+{
+class ClientCertificatePasswordDialog;
+}
+
+namespace Esri
+{
+namespace ArcGISRuntime
+{
+
+namespace Toolkit
+{
+
+class AuthenticationController;
+
+class ClientCertificatePasswordDialog : public QDialog 
+{
+  Q_OBJECT
+public:
+  explicit ClientCertificatePasswordDialog(QUrl certificateFile, AuthenticationController* controller, QWidget* parent = nullptr);
+  ~ClientCertificatePasswordDialog() override;
+
+private:
+  QUrl m_certificateFile{};
+  AuthenticationController* m_controller;
+  Ui::ClientCertificatePasswordDialog* m_ui = nullptr;
+};
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri
+
+#endif // ESRI_ARCGISRUNTIME_CLIENTCERTIFICATEPASSWORDDIALOG_H

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificatePasswordDialog.ui
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificatePasswordDialog.ui
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ClientCertificatePasswordDialog</class>
+ <widget class="QDialog" name="ClientCertificatePasswordDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>345</width>
+    <height>97</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="preamble">
+     <property name="text">
+      <string>The client certificate file requires a password to open.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="passwordEdit">
+     <property name="echoMode">
+      <enum>QLineEdit::Password</enum>
+     </property>
+     <property name="placeholderText">
+      <string>password</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ClientCertificatePasswordDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>224</x>
+     <y>183</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>96</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ClientCertificatePasswordDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>292</x>
+     <y>183</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>96</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>passwordEdit</sender>
+   <signal>returnPressed()</signal>
+   <receiver>ClientCertificatePasswordDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>172</x>
+     <y>150</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>172</x>
+     <y>100</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificateView.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificateView.cpp
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#include "ClientCertificateView.h"
+#include "ui_ClientCertificateView.h"
+
+#include "ClientCertificatePasswordDialog.h"
+
+#include "AuthenticationController.h"
+
+#include <QStringListModel>
+#include <QFileDialog>
+#include <QStandardPaths>
+
+namespace Esri
+{
+namespace ArcGISRuntime
+{
+namespace Toolkit
+{
+
+/*!
+  \brief Constructor.
+  \list
+    \li \a parent Parent widget.
+  \endlist
+ */
+ClientCertificateView::ClientCertificateView(AuthenticationController* controller, QWidget* parent) :
+  QWidget(parent),
+  m_controller(controller),
+  m_ui(new Ui::ClientCertificateView)
+{
+  m_ui->setupUi(this);
+
+  // Show the appropriate certificate preable.
+  m_ui->preamble->setText(QString(tr("The service has requested a client certificate to authenticate you. "
+                                     "The app has identified the requesting server as "
+                                     "'%1', but you "
+                                     "should only give the app access to the certificate if you trust it."))
+                              .arg(m_controller->currentAuthenticatingHost()));
+
+  // Setup ListView to show live client certificate infos.
+  auto model = new QStringListModel(m_controller->clientCertificateInfos(), this);
+  connect (m_controller, &AuthenticationController::clientCertificateInfosChanged, model, [this, model]()
+  {
+      model->setStringList(m_controller->clientCertificateInfos());
+  });
+  m_ui->certificatesView->setModel(model);
+
+  // Setup the Ok button to only enable when a certificate is selected.
+  auto ok_button =  m_ui->buttonBox->button(QDialogButtonBox::StandardButton::Ok);
+  Q_ASSERT(ok_button);
+  ok_button->setEnabled(false);
+  auto selection_model = m_ui->certificatesView->selectionModel();
+  selection_model->clearSelection();
+  connect(selection_model, &QItemSelectionModel::currentChanged, ok_button,
+          [ok_button](const QModelIndex& current)
+          {
+            ok_button->setEnabled(current.isValid());
+          });
+
+  // Add a client certificate on request.
+  connect(m_ui->addCertificateButton, &QPushButton::pressed, this,
+          [this]
+          {
+            auto fileUrl = QFileDialog::getOpenFileUrl(
+                this,
+                tr("Add certificate"),
+                QStandardPaths::writableLocation(QStandardPaths::StandardLocation::DocumentsLocation));
+
+            if (fileUrl.isEmpty())
+            {
+              return;
+            }
+            m_controller->addClientCertificate(fileUrl);
+          }, Qt::QueuedConnection);
+
+  // Prompt for a password when required.
+  connect(m_controller, &AuthenticationController::clientCertificatePasswordRequired, this,
+          [this](QUrl certificate)
+          {
+            auto dialog = new ClientCertificatePasswordDialog(std::move(certificate), m_controller, this);
+            dialog->exec();
+          }, Qt::QueuedConnection);
+}
+
+ClientCertificateView::~ClientCertificateView()
+{
+  delete m_ui;
+}
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificateView.h
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificateView.h
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#ifndef ESRI_ARCGISRUNTIME_CLIENTCERTIFICATEVIEW_H
+#define ESRI_ARCGISRUNTIME_CLIENTCERTIFICATEVIEW_H
+
+#include <QWidget>
+
+namespace Ui
+{
+class ClientCertificateView;
+}
+
+namespace Esri
+{
+namespace ArcGISRuntime
+{
+
+namespace Toolkit
+{
+
+class AuthenticationController;
+
+class ClientCertificateView : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit ClientCertificateView(AuthenticationController* controller, QWidget* parent = nullptr);
+  ~ClientCertificateView() override;
+
+private:
+  AuthenticationController* m_controller = nullptr;
+  Ui::ClientCertificateView* m_ui = nullptr;
+};
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri
+
+#endif // ESRI_ARCGISRUNTIME_CLIENTCERTIFICATEVIEW_H

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificateView.ui
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificateView.ui
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ClientCertificateView</class>
+ <widget class="QWidget" name="ClientCertificateView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>306</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Client certificate requested</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="userTitle">
+     <property name="font">
+      <font>
+       <pointsize>22</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Client certificate requested</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
+     <property name="scaledContents">
+      <bool>false</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="preamble">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>The service has requested a client certificate to authenticate you.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListView" name="certificatesView">
+     <property name="alternatingRowColors">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="addCertificateButton">
+     <property name="text">
+      <string>Add certificate</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Ignore|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/OAuth2View.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/OAuth2View.cpp
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#include "OAuth2View.h"
+#include "ui_OAuth2View.h"
+
+#include "AuthenticationController.h"
+
+namespace Esri
+{
+namespace ArcGISRuntime
+{
+namespace Toolkit
+{
+
+namespace 
+{
+  bool isSuccess(const QString& title)
+  {
+    return title.indexOf("SUCCESS code=") > -1;
+  }
+
+  bool isInvalidRequest(const QString& title) 
+  {
+      return (title.indexOf("Denied error=invalid_request") > -1);
+  }
+
+  bool isError(const QString& title) 
+  {
+    return (title.indexOf("Denied error=") > -1) || (title.indexOf("Error: ") > -1);
+  }
+}
+
+/*!
+  \brief Constructor.
+  \list
+    \li \a parent Parent widget.
+  \endlist
+ */
+OAuth2View::OAuth2View(AuthenticationController* controller, QWidget* parent) :
+  QWidget(parent),
+  m_controller(controller),
+  m_ui(new Ui::OAuth2View)
+{
+  m_ui->setupUi(this);
+
+  connect(m_ui->buttonBox, &QDialogButtonBox::rejected,
+        [this]
+        {
+          if(m_controller)
+          {
+            m_controller->cancel();
+          }
+        });
+
+  connect(m_ui->webView, &QWebEngineView::titleChanged, this,
+  [this](const QString& title)
+  {
+    setWindowTitle(title);
+    if (isSuccess(title))
+    {
+      auto authCode = title;
+      authCode.replace("SUCCESS code=", "");
+      m_controller->continueWithOAuthAuthorizationCode(authCode);
+    } 
+    else if (isInvalidRequest(title))
+    {
+      m_controller->cancelWithError(title, "Invalid request");
+    }
+    else if (isError(title))
+    {
+      m_controller->cancelWithError(title, "Unspecified error");
+    }
+  });
+
+  connect(m_ui->webView, &QWebEngineView::loadFinished, this,
+  [this](bool ok)
+  {
+    if(!ok)
+    {
+      m_controller->cancelWithError("Failed to load", "");
+    }
+  });
+  m_ui->webView->load(m_controller->currentChallengeUrl());
+}
+
+OAuth2View::~OAuth2View()
+{
+  delete m_ui;
+}
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/OAuth2View.h
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/OAuth2View.h
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#ifndef ESRI_ARCGISRUNTIME_OAUTH2VIEW_H
+#define ESRI_ARCGISRUNTIME_OAUTH2VIEW_H
+
+#include <QWidget>
+
+namespace Ui
+{
+class OAuth2View;
+}
+
+namespace Esri
+{
+namespace ArcGISRuntime
+{
+
+namespace Toolkit
+{
+
+class AuthenticationController;
+
+class OAuth2View : public QWidget 
+{
+  Q_OBJECT
+public:
+  explicit OAuth2View(AuthenticationController* controller, QWidget* parent = nullptr);
+  ~OAuth2View() override;
+
+private:
+  AuthenticationController* m_controller = nullptr;
+  Ui::OAuth2View* m_ui = nullptr;
+};
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri
+
+#endif // ESRI_ARCGISRUNTIME_OAUTH2VIEW_H

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/OAuth2View.ui
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/OAuth2View.ui
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>OAuth2View</class>
+ <widget class="QWidget" name="OAuth2View">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Authentication Required</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QWebEngineView" name="webView" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>800</width>
+       <height>600</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QWebEngineView</class>
+   <extends>QWidget</extends>
+   <header location="global">QWebEngineView</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/SslHandshakeView.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/SslHandshakeView.cpp
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#include "SslHandshakeView.h"
+#include "ui_SslHandshakeView.h"
+
+#include "AuthenticationController.h"
+
+namespace Esri
+{
+namespace ArcGISRuntime
+{
+namespace Toolkit
+{
+
+/*!
+  \brief Constructor.
+  \list
+    \li \a parent Parent widget.
+  \endlist
+ */
+SslHandshakeView::SslHandshakeView(AuthenticationController* controller, QWidget* parent) :
+  QWidget(parent),
+  m_controller(controller),
+  m_ui(new Ui::SslHandshakeView)
+{
+  m_ui->setupUi(this);
+  connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, 
+          [this]
+          {
+            if (m_controller)
+              m_controller->continueWithSslHandshake(
+                  true, m_ui->rememberBox->isChecked());
+          });
+  connect(m_ui->buttonBox, &QDialogButtonBox::rejected, this,
+          [this]
+          {
+            if (m_controller)
+              m_controller->continueWithSslHandshake(
+                false, m_ui->rememberBox->isChecked());
+          });
+}
+
+SslHandshakeView::~SslHandshakeView()
+{
+  delete m_ui;
+}
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/SslHandshakeView.h
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/SslHandshakeView.h
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#ifndef ESRI_ARCGISRUNTIME_SSLHANDSHAKEVIEW_H
+#define ESRI_ARCGISRUNTIME_SSLHANDSHAKEVIEW_H
+
+#include <QWidget>
+
+namespace Ui
+{
+class SslHandshakeView;
+}
+
+namespace Esri
+{
+namespace ArcGISRuntime
+{
+
+namespace Toolkit
+{
+
+class AuthenticationController;
+
+class SslHandshakeView : public QWidget
+{
+  Q_OBJECT
+public:
+  explicit SslHandshakeView(AuthenticationController* controller, QWidget* parent = nullptr);
+  ~SslHandshakeView() override;
+
+private:
+  AuthenticationController* m_controller = nullptr;
+  Ui::SslHandshakeView* m_ui = nullptr;
+};
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri
+
+#endif // ESRI_ARCGISRUNTIME_SSLHANDSHAKEVIEW_H

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/SslHandshakeView.ui
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/SslHandshakeView.ui
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SslHandshakeView</class>
+ <widget class="QWidget" name="SslHandshakeView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>371</width>
+    <height>179</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Untrusted host</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetFixedSize</enum>
+   </property>
+   <item row="0" column="0" colspan="3">
+    <widget class="QLabel" name="userTitle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>22</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Untrusted host</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
+     <property name="scaledContents">
+      <bool>false</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <widget class="QLabel" name="message">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>The server could not prove itself; its security certificate is not trusted by your OS. Would you like to continue anyway?</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QCheckBox" name="rememberBox">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Remember</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::No|QDialogButtonBox::Yes</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/UserCredentialView.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/UserCredentialView.cpp
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#include "UserCredentialView.h"
+#include "ui_UserCredentialView.h"
+
+#include "AuthenticationController.h"
+
+namespace Esri
+{
+namespace ArcGISRuntime
+{
+namespace Toolkit
+{
+
+/*!
+  \brief Constructor.
+  \list
+    \li \a parent Parent widget.
+  \endlist
+ */
+UserCredentialView::UserCredentialView(AuthenticationController* controller, QWidget* parent) :
+  QWidget(parent),
+  m_controller(controller),
+  m_ui(new Ui::UserCredentialView)
+{
+  m_ui->setupUi(this);
+  if (m_controller && m_controller->currentChallengeFailureCount() < 2)
+  {
+    m_ui->incorrectMessage->setVisible(false);
+  }
+
+  connect(m_ui->usernameEdit, &QLineEdit::returnPressed, this, &UserCredentialView::acceptWithUsernamePassword);
+  connect(m_ui->passwordEdit, &QLineEdit::returnPressed, this, &UserCredentialView::acceptWithUsernamePassword);
+  connect(m_ui->buttonBox, &QDialogButtonBox::accepted, this, &UserCredentialView::acceptWithUsernamePassword);
+  connect(m_ui->buttonBox, &QDialogButtonBox::rejected,
+          [this]
+          {
+            m_controller ? m_controller->cancel() : void();
+          });
+}
+
+UserCredentialView::~UserCredentialView()
+{
+  delete m_ui;
+}
+
+void UserCredentialView::acceptWithUsernamePassword()
+{
+  if (!m_controller)
+  {
+    return;
+  }
+  m_controller->continueWithUsernamePassword(m_ui->usernameEdit->text(), m_ui->passwordEdit->text());
+}
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/UserCredentialView.h
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/UserCredentialView.h
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#ifndef ESRI_ARCGISRUNTIME_USERCREDENTIALVIEW_H
+#define ESRI_ARCGISRUNTIME_USERCREDENTIALVIEW_H
+
+#include <QWidget>
+
+namespace Ui
+{
+class UserCredentialView;
+}
+
+namespace Esri
+{
+namespace ArcGISRuntime
+{
+
+namespace Toolkit
+{
+
+class AuthenticationController;
+
+class UserCredentialView : public QWidget 
+{
+  Q_OBJECT
+public:
+  explicit UserCredentialView(AuthenticationController* controller, QWidget* parent = nullptr);
+  ~UserCredentialView() override;
+  
+private slots:
+  void acceptWithUsernamePassword();
+
+private:
+  AuthenticationController* m_controller = nullptr;
+  Ui::UserCredentialView* m_ui = nullptr;
+};
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri
+
+#endif // ESRI_ARCGISRUNTIME_USERCREDENTIALVIEW_H

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/UserCredentialView.ui
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/UserCredentialView.ui
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UserCredentialView</class>
+ <widget class="QWidget" name="UserCredentialView">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>204</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Authentication Required</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLabel" name="userTitle">
+     <property name="font">
+      <font>
+       <pointsize>22</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Authentication required</string>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::PlainText</enum>
+     </property>
+     <property name="scaledContents">
+      <bool>false</bool>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="incorrectMessage">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: &quot;red&quot;;
+background-color: &quot;#FFCCCC&quot;;
+</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <property name="lineWidth">
+      <number>2</number>
+     </property>
+     <property name="text">
+      <string>Invalid username or password.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="message">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>You need to sign in to access this resource.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="usernameEdit">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="placeholderText">
+      <string>username</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="passwordEdit">
+     <property name="echoMode">
+      <enum>QLineEdit::Password</enum>
+     </property>
+     <property name="placeholderText">
+      <string>password</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Hi guys, here is the AuthenticationView widgets attempt. 

## OAuth

<img width="1016" alt="image" src="https://user-images.githubusercontent.com/42203545/117337211-04462c80-ae95-11eb-9dae-c98132c58317.png">

## SSL

<img width="798" alt="image" src="https://user-images.githubusercontent.com/42203545/117337216-05775980-ae95-11eb-9524-da1d7898babc.png">

## User credentials

<img width="799" alt="image" src="https://user-images.githubusercontent.com/42203545/117337206-027c6900-ae95-11eb-881e-ceb5acb71ff8.png">

## Client certificate view

<img width="798" alt="image" src="https://user-images.githubusercontent.com/42203545/117337222-06a88680-ae95-11eb-8b52-e9455151a81a.png">
