### PR TITLE
Scaleline Qt Quick C++ implementation 

### DIFF
--- a/uitools/common.pri
+++ b/uitools/common.pri
@@ -33,6 +33,7 @@ HEADERS += $$CPPPATH/AuthenticationController.h \
            $$CPPPATH/NorthArrowController.h \
            $$CPPPATH/OverviewMapController.h \
            $$CPPPATH/PopupViewController.h \
+           $$CPPPATH/ScalelineController.h \
            $$CPPPATH/TimeSliderController.h
 
 SOURCES += $$CPPPATH/AuthenticationController.cpp \
@@ -50,4 +51,5 @@ SOURCES += $$CPPPATH/AuthenticationController.cpp \
            $$CPPPATH/NorthArrowController.cpp \
            $$CPPPATH/OverviewMapController.cpp \
            $$CPPPATH/PopupViewController.cpp \
+           $$CPPPATH/ScalelineController.cpp \
            $$CPPPATH/TimeSliderController.cpp

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/ScalelineController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/ScalelineController.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright 2012-2020 Esri
+ *  Copyright 2012-2021 Esri
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/ScalelineController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/ScalelineController.cpp
@@ -1,0 +1,266 @@
+/*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#include "ScalelineController.h"
+
+// C++ headers
+#include <cmath>
+
+// ArcGISRuntime headers
+#include <GeometryEngine.h>
+#include <PolylineBuilder.h>
+
+namespace Esri {
+namespace ArcGISRuntime {
+namespace Toolkit {
+
+  namespace {
+
+    constexpr double MULTIPLIERS[] = {
+        1,
+        1.2,
+        1.25,
+        1.5,
+        1.75,
+        2.0,
+        2.4,
+        2.5,
+        3,
+        3.75,
+        4,
+        5,
+        6,
+        7.5,
+        8.0,
+        9.0,
+        10,
+    };
+
+    double selectMultiplierData(double distance, double magnitude)
+    {
+      double residual = distance / magnitude;
+      return std::accumulate(
+          std::cbegin(MULTIPLIERS),
+          std::cend(MULTIPLIERS), MULTIPLIERS[0],
+          [residual](double i, double m)
+          {
+            return m < residual && m > i ? m : i;
+          });
+    }
+
+    /*
+      Calculates the "magnitude" used when calculating the length of a scalebar or the number of segments. This is the
+      largest power of 10 that's less than or equal to a given distance
+    */
+    double calculateMagnitude(double distance)
+    {
+      return pow(10, floor(log10(distance)));
+    }
+
+    LinearUnit selectLinearUnit(double distance, UnitSystem unitSystem)
+    {
+      switch (unitSystem)
+      {
+      case UnitSystem::Imperial:
+        // use MILES if at least half a mile
+        if (distance >= 2640)
+        {
+          return LinearUnit{LinearUnitId::Miles};
+        }
+        return LinearUnit{LinearUnitId::Feet};
+
+      case UnitSystem::Metric:
+      default:
+        // use KILOMETERS if at least one kilometer
+        if (distance >= 1000)
+        {
+          return LinearUnit{LinearUnitId::Kilometers};
+        }
+        return LinearUnit{LinearUnitId::Meters};
+      }
+    }
+  }
+
+  /*!
+  \class Esri::ArcGISRuntime::Toolkit::ScalelineController
+  \inmodule EsriArcGISRuntimeToolkit
+  \ingroup ArcGISQtToolkitUiCppControllers
+  \brief In MVC architecture, this is the controller for the corresponding
+  \c Scaleline view.
+ */
+
+  /*!
+  \brief Constructor
+  \list
+    \li \a parent Parent owning \c QObject.
+  \endlist
+ */
+  ScalelineController::ScalelineController(QObject* parent) :
+    QObject(parent)
+  {
+  }
+
+  /*!
+  \brief Destructor.
+ */
+  ScalelineController::~ScalelineController()
+  {
+  }
+
+  QObject* ScalelineController::mapView() const
+  {
+    return m_mapView;
+  }
+
+  void ScalelineController::setMapView(QObject* qObject)
+  {
+    auto mapView = qobject_cast<MapViewToolkit*>(qObject);
+
+    if (m_mapView == mapView)
+      return;
+
+    m_mapView = mapView;
+    emit mapViewChanged();
+  }
+
+  int ScalelineController::unitSystem()
+  {
+    return static_cast<int>(m_unitSystem);
+  }
+
+  void ScalelineController::setUnitSystem(int unitSystem)
+  {
+    if (static_cast<int>(m_unitSystem) == unitSystem)
+      return;
+
+    m_unitSystem = static_cast<UnitSystem>(unitSystem);
+
+    switch (m_unitSystem)
+    {
+    case UnitSystem::Imperial:
+      m_baseUnit = LinearUnit{LinearUnitId::Feet};
+      break;
+    case UnitSystem::Metric:
+    default:
+      m_baseUnit = LinearUnit{LinearUnitId::Meters};
+      break;
+    }
+
+    emit unitSystemChanged();
+  }
+
+  double ScalelineController::calculateBestScalebarLength(double maxLength)
+  {
+    return calculateBestScalebarLength(maxLength, m_baseUnit);
+  }
+
+  double ScalelineController::calculateBestScalebarLength(double maxLength, LinearUnit unit)
+  {
+    double magnitude = calculateMagnitude(maxLength);
+    double multiplier = selectMultiplierData(maxLength, magnitude);
+
+    double bestLength = multiplier * magnitude;
+
+    // If using imperial units, check if the number of feet is greater than the threshold for using feet
+    if (unit.linearUnitId() == LinearUnitId::Feet)
+    {
+      LinearUnit displayUnits = selectLinearUnit(bestLength, UnitSystem::Imperial);
+      if (unit.linearUnitId() != displayUnits.linearUnitId())
+      {
+        // Recalculate the best length in miles
+        bestLength = calculateBestScalebarLength(unit.convertTo(displayUnits, maxLength), displayUnits);
+        // But convert that back to feet because the caller is using feet
+        return displayUnits.convertTo(unit, bestLength);
+      }
+    }
+    return bestLength;
+  }
+
+  double ScalelineController::calculateDistance(double width)
+  {
+    double distance = 0.0;
+
+    if (!m_mapView)
+    {
+      return distance;
+    }
+
+    Polygon visibleArea = m_mapView->visibleArea();
+    if (!visibleArea.isEmpty())
+    {
+      Point mapCenter = visibleArea.extent().center();
+      if (!mapCenter.isEmpty())
+      {
+        double maxPlanarWidth = m_mapView->unitsPerDIP() * width;
+        Point point1 = Point(mapCenter.x() - (maxPlanarWidth / 2.0), mapCenter.y());
+        Point point2 = Point(mapCenter.x() + (maxPlanarWidth / 2.0), mapCenter.y());
+
+        auto builder = std::make_unique<PolylineBuilder>(m_mapView->spatialReference());
+        builder->addPoint(point1);
+        builder->addPoint(mapCenter);
+        builder->addPoint(point2);
+
+        distance = GeometryEngine::lengthGeodetic(builder->toGeometry(), m_baseUnit, GeodeticCurveType::Geodesic);
+      }
+    }
+
+    return distance;
+  }
+
+  double ScalelineController::calculateDisplayWidth(double displayDistance, double maximumDistance, double availableWidth)
+  {
+    return displayDistance / maximumDistance * availableWidth;
+  }
+
+  QString ScalelineController::calculateDistanceInDisplayUnits(double distance, int unitSystem)
+  {
+    return calculateDistanceInDisplayUnits(distance, static_cast<UnitSystem>(unitSystem));
+  }
+
+  /**
+   * Calculates the distance value to display in the correct units.
+   *
+   * @param distance the distance in the base unit
+   * @param baseUnit the base unit
+   * @param displayUnit the display unit
+   * @return the distance to display
+   * @throws NullPointerException if baseUnit is null
+   * @throws NullPointerException if displayUnit is null
+   * @since 100.2.1
+   */
+  QString ScalelineController::calculateDistanceInDisplayUnits(double distance, UnitSystem unitSystem)
+  {
+    double displayDistance = distance;
+    LinearUnit displayUnit = selectLinearUnit(distance, unitSystem);
+    if (displayUnit.unitId() != m_baseUnit.unitId())
+    {
+      displayDistance = m_baseUnit.convertTo(displayUnit, displayDistance);
+    }
+
+    return QString{"%1 %2"}.arg(displayDistance).arg(displayUnit.abbreviation());
+  }
+
+  /*!
+  \fn void Esri::ArcGISRuntime::Toolkit::ScalelineController::geoViewChanged()
+  \brief Emitted when the geoView changes.
+ */
+
+  /*!
+  \property Esri::ArcGISRuntime::Toolkit::ScalelineController::geoView
+ */
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/ScalelineController.h
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/ScalelineController.h
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ *  Copyright 2012-2020 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+#ifndef ESRI_ARCGISRUNTIME_TOOLKIT_SCALELINECONTROLLER_H
+#define ESRI_ARCGISRUNTIME_TOOLKIT_SCALELINECONTROLLER_H
+
+// Qt headers
+#include <QObject>
+
+// ArcGISRuntime headers
+#include <CoreTypes.h>
+#include <LinearUnit.h>
+
+// Toolkit headers
+#include "Internal/GeoViews.h"
+
+namespace Esri {
+namespace ArcGISRuntime {
+namespace Toolkit {
+
+  class ScalelineController : public QObject
+  {
+    Q_OBJECT
+    Q_PROPERTY(QObject* mapView READ mapView WRITE setMapView NOTIFY mapViewChanged)
+    Q_PROPERTY(int unitSystem READ unitSystem WRITE setUnitSystem NOTIFY unitSystemChanged)
+  public:
+    Q_INVOKABLE ScalelineController(QObject* parent = nullptr);
+
+    ~ScalelineController();
+
+    QObject* mapView() const;
+    void setMapView(QObject* geoView);
+
+    int unitSystem();
+    void setUnitSystem(int unitSystem);
+
+    double calculateBestScalebarLength(double maxLength, LinearUnit units);
+
+    Q_INVOKABLE double calculateBestScalebarLength(double maxLength);
+
+    Q_INVOKABLE double calculateDistance(double width);
+
+    Q_INVOKABLE double calculateDisplayWidth(double displayDistance, double maximumDistance, double availableWidth);
+
+    Q_INVOKABLE QString calculateDistanceInDisplayUnits(double distance, int unitSystem);
+    QString calculateDistanceInDisplayUnits(double distance, UnitSystem unitSystem);
+
+  signals:
+    void mapViewChanged();
+    void unitSystemChanged();
+    void viewpointChanged();
+
+  private:
+    MapViewToolkit* m_mapView{nullptr};
+    UnitSystem m_unitSystem{UnitSystem::Metric};
+    LinearUnit m_baseUnit{LinearUnitId::Meters};
+  };
+
+} // Toolkit
+} // ArcGISRuntime
+} // Esri
+
+#endif // ESRI_ARCGISRUNTIME_TOOLKIT_NORTHARROWCONTROLLER_H

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/ScalelineController.h
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/ScalelineController.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright 2012-2020 Esri
+ *  Copyright 2012-2021 Esri
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/ScalelineController.h
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/ScalelineController.h
@@ -34,7 +34,7 @@ namespace Toolkit {
   {
     Q_OBJECT
     Q_PROPERTY(QObject* mapView READ mapView WRITE setMapView NOTIFY mapViewChanged)
-    Q_PROPERTY(int unitSystem READ unitSystem WRITE setUnitSystem NOTIFY unitSystemChanged)
+    Q_PROPERTY(UnitSystem unitSystem READ unitSystem WRITE setUnitSystem NOTIFY unitSystemChanged)
   public:
     Q_INVOKABLE ScalelineController(QObject* parent = nullptr);
 
@@ -43,8 +43,8 @@ namespace Toolkit {
     QObject* mapView() const;
     void setMapView(QObject* geoView);
 
-    int unitSystem();
-    void setUnitSystem(int unitSystem);
+    UnitSystem unitSystem();
+    void setUnitSystem(UnitSystem unitSystem);
 
     double calculateBestScalebarLength(double maxLength, LinearUnit units);
 
@@ -54,8 +54,7 @@ namespace Toolkit {
 
     Q_INVOKABLE double calculateDisplayWidth(double displayDistance, double maximumDistance, double availableWidth);
 
-    Q_INVOKABLE QString calculateDistanceInDisplayUnits(double distance, int unitSystem);
-    QString calculateDistanceInDisplayUnits(double distance, UnitSystem unitSystem);
+    Q_INVOKABLE QString calculateDistanceInDisplayUnits(double distance, UnitSystem unitSystem);
 
   signals:
     void mapViewChanged();

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/TimeSliderController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/TimeSliderController.cpp
@@ -58,7 +58,7 @@ namespace
       listModel->cbegin(),
       listModel->cend(),
       T{},
-      [f{std::move(f)}](const T& val, Layer* layer)
+      [f = std::move(f)](const T& val, Layer* layer)
       {
         if (!layer || layer->loadStatus() != LoadStatus::Loaded)
           return val;

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/ScaleLineController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/ScaleLineController.qml
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ *  Copyright 2012-2021 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+
+import QtQml 2.12
+
+/*!
+   \qmltype ScalineLineController
+   \inqmlmodule Esri.ArcGISRuntime.Toolkit
+   \since Esri.ArcGISRuntime 100.13
+   \ingroup ArcGISQtToolkitUiQmlControllers
+   \brief In MVC architecture, this is the controller for the corresponding
+    \c Scaleline view.
+
+    This controller object handles the Scaleline calculations for a Scaleline's width
+    and display units, based on a given mapview and owning scaleline's bounds.
+ */
+QtObject {
+
+  property var mapView;
+
+  property var unitSystem;
+
+  Component.onCompleted: {
+    console.error("Sorry, Scaleline has not been implemented for QML.")
+  }
+}

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/esri_arcgisruntime_toolkit_controller.qrc
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/esri_arcgisruntime_toolkit_controller.qrc
@@ -11,6 +11,7 @@
       <file>NorthArrowController.qml</file>
       <file>OverviewMapController.qml</file>
       <file>PopupViewController.qml</file>
+      <file>ScalelineController.qml</file>
       <file>TimeSliderController.qml</file>
       <file>qmldir</file>
     </qresource>

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/qmldir
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/qmldir
@@ -27,4 +27,5 @@ CoordinateConversionResult 100.10 CoordinateConversionResult.qml
 NorthArrowController 100.10 NorthArrowController.qml
 OverviewMapController 100.12 OverviewMapController.qml
 PopupViewController 100.10 PopupViewController.qml
+ScalelineController 100.13 ScalelineController.qml
 TimeSliderController 100.10 TimeSliderController.qml

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -74,7 +74,6 @@ Control {
       \qmlproperty PopupViewController controller
       \brief the Controller handles reading from the PopupManager and monitoring
       the list-models.
-      \qmlproperty PopupViewController controller
     */
     property var controller: PopupViewController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/ScaleLine.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/ScaleLine.qml
@@ -1,0 +1,63 @@
+import QtQuick 2.15
+import QtQml 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Shapes 1.15
+
+import Esri.ArcGISRuntime.Toolkit 100.13
+import Esri.ArcGISRuntime.Toolkit.Controller 100.13
+
+Control {
+    id: scaleLine
+
+    property var mapView;
+
+    /*!
+  \qmlproperty ScalelineController controller
+  \brief
+  */
+    property var controller: ScalelineController { }
+
+    spacing: 5
+    implicitWidth: 100
+    implicitHeight: font.pixelSize + spacing
+
+    enum Style {
+        Ruler,
+        Line
+    }
+
+    enum UnitSystem {
+        Imperial = 0,
+        Metric = 1,
+        Dual = 99
+    }
+
+    property int unitSystem: Scaleline.UnitSystem.Metric
+
+    contentItem: Column {
+        ScalelineImpl {
+            //anchors.top: parent
+            controller: scaleLine.controller
+            unitSystem: unitSystem === unitSystem.Dual ? Scaleline.UnitSystem.Metric : unitSystem
+        }
+//        ScalelineImpl {
+//            //anchors.top: parent
+//            controller: scaleLine.controller
+//            unitSystem: Scaleline.UnitSystem.Imperial
+//            visible: unitSystem === Scaleline.UnitSystem.Dual
+//        }
+    }
+
+    Binding {
+        restoreMode: Binding.RestoreNone
+        target: controller
+        property: "mapView"
+        value: mapView
+    }
+
+    onMapViewChanged: {
+        if (controller) {
+            controller.mapView = mapView;
+        }
+    }
+}

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/ScaleLine.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/ScaleLine.qml
@@ -6,46 +6,92 @@ import QtQuick.Shapes 1.15
 import Esri.ArcGISRuntime.Toolkit 100.13
 import Esri.ArcGISRuntime.Toolkit.Controller 100.13
 
+/*!
+   \qmltype Scaleline
+   \ingroup ArcGISQtToolkit
+   \ingroup ArcGISQtToolkitUiQmlViews
+   \inqmlmodule Esri.ArcGISRuntime.Toolkit
+   \since Esri.ArcGISRuntime 100.13
+   \brief A Scaleline control that shows an accurate distance that can be used to visually gauge distances on a map view. The
+    measurement system used is controlled by \l{unitSystem}. The units used will be appropriate to the
+    distance being shown e.g. \c{km} for long distances and \c{m} for shorter distances.
+ */
 Control {
     id: scaleLine
 
+    /*!
+     \qmlproperty MapView mapView
+     \brief The mapView in which the displayed distance and width
+     of this Scaleline are calculated from.
+     */
     property var mapView;
 
     /*!
-  \qmlproperty ScalelineController controller
-  \brief
-  */
+     \qmlproperty ScalelineController controller
+      \brief The controller portion of the Scaleline which handles
+      distance calculations based on the visual properties of the given
+      \l{mapView}.
+     */
     property var controller: ScalelineController { }
 
     spacing: 5
     implicitWidth: 100
     implicitHeight: font.pixelSize + spacing
 
+    // TODO: Implement and remove `\internal`.
+    /*
+      \internal
+      \brief The Styles of the Scaleline.
+
+      Valid options are:
+
+      \value Style.Ruler The Scaleline is displayed as a ruler.
+      \value Style.Line The Scaleline is displayed as a line.
+
+      The default is \c Style.Line.
+     */
     enum Style {
         Ruler,
         Line
     }
 
+    // TODO: Allow for dual display.
+    // Future maintainers, please note that
+    // the values map to the `UnitSystem` enumeration.
+    // Which is why `Dual` is a high value as not to conflict.
+    /*
+      \brief The Unitss of the Scaleline.
+
+      Valid options are:
+
+      \value UnitSystem.Imperial Units are in miles and feet.
+      \value UnitSystem.Metric Units are in kilometers and meters.
+
+      The default is \c UnitSystem.Metric.
+     */
     enum UnitSystem {
         Imperial = 0,
         Metric = 1,
         Dual = 99
     }
 
+    /*!
+     \qmlproperty UnitSystem unitSystem
+      \brief The display units of the Scaleline, can be metric, imperial.
+             The default is \c UnitSystem.Metric.
+     */
     property int unitSystem: Scaleline.UnitSystem.Metric
 
     contentItem: Column {
         ScalelineImpl {
-            //anchors.top: parent
+            spacing: scaleLine.spacing
+            implicitWidth: scaleLine.implicitWidth
+            implicitHeight: scaleLine.implicitHeight
+            font: scaleLine.font
+            palette: scaleLine.palette
             controller: scaleLine.controller
             unitSystem: unitSystem === unitSystem.Dual ? Scaleline.UnitSystem.Metric : unitSystem
         }
-//        ScalelineImpl {
-//            //anchors.top: parent
-//            controller: scaleLine.controller
-//            unitSystem: Scaleline.UnitSystem.Imperial
-//            visible: unitSystem === Scaleline.UnitSystem.Dual
-//        }
     }
 
     Binding {

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/ScaleLine.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/ScaleLine.qml
@@ -1,3 +1,19 @@
+/*******************************************************************************
+ *  Copyright 2012-2021 Esri
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ ******************************************************************************/
+
 import QtQuick 2.15
 import QtQml 2.15
 import QtQuick.Controls 2.15

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/ScaleLineImpl.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/ScaleLineImpl.qml
@@ -5,20 +5,27 @@ import QtQuick.Shapes 1.15
 
 import Esri.ArcGISRuntime.Toolkit.Controller 100.13
 
+/*!
+  \internal
+  This is the display portion of a Scaleline. A single scaleline can be
+  composed of multiple display portions (i.e. showing imperial and metric scalelines side
+  by side).
+ */
 Control {
     id: scaleLine
 
     /*!
-  \qmlproperty ScalelineController controller
-  \brief
-  */
+      \qmlproperty ScalelineController controller
+      \brief The controller used for calculations based on the mapView.
+    */
     property var controller: null
 
+    /*!
+      \qmlproperty unitSystem
+      \brief UnitSystem for the Scaleline. For this display portion,
+      only metric and imperial are valid values.
+    */
     property int unitSystem
-
-    spacing: 5
-    implicitWidth: 100
-    implicitHeight: font.pixelSize + spacing
 
     contentItem: Shape {
         anchors.fill:parent
@@ -26,10 +33,10 @@ Control {
             strokeColor: "black"
             strokeWidth: 3
             fillColor: Qt.rgba(255, 255, 255, 0.5)
-            startX: 0; startY: scaleLine.height
-            PathLine { x: 0; y: 0 }
-            PathLine { x: internal.displayWidth; y: 0 }
+            startX: 0; startY: 0
+            PathLine { x: 0; y: scaleLine.height }
             PathLine { x: internal.displayWidth; y: scaleLine.height }
+            PathLine { x: internal.displayWidth; y: 0 }
         }
         Label {
             anchors {

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/ScaleLineImpl.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/ScaleLineImpl.qml
@@ -1,0 +1,78 @@
+import QtQuick 2.15
+import QtQml 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Shapes 1.15
+
+import Esri.ArcGISRuntime.Toolkit.Controller 100.13
+
+Control {
+    id: scaleLine
+
+    /*!
+  \qmlproperty ScalelineController controller
+  \brief
+  */
+    property var controller: null
+
+    property int unitSystem
+
+    spacing: 5
+    implicitWidth: 100
+    implicitHeight: font.pixelSize + spacing
+
+    contentItem: Shape {
+        anchors.fill:parent
+        ShapePath {
+            strokeColor: "black"
+            strokeWidth: 3
+            fillColor: Qt.rgba(255, 255, 255, 0.5)
+            startX: 0; startY: scaleLine.height
+            PathLine { x: 0; y: 0 }
+            PathLine { x: internal.displayWidth; y: 0 }
+            PathLine { x: internal.displayWidth; y: scaleLine.height }
+        }
+        Label {
+            anchors {
+                left: parent.left
+                verticalCenter: parent.verticalCenter
+                leftMargin: scaleLine.spacing
+            }
+            font: scaleLine.font
+            palette: scaleLine.palette
+            text: internal.displayDistance
+        }
+    }
+
+    Component.onCompleted: {
+        if (controller.mapView) {
+            internal.calculateScale();
+        }
+    }
+
+    QtObject {
+        id: internal
+
+        property real displayWidth
+        property string displayDistance
+
+        function calculateScale() {
+            // Get the total scalebar width in pixels.
+            const availableWidth = scaleLine.width;
+            // Get the possible longest distance the scalebar would cover.
+            const maxDistance = controller.calculateDistance(availableWidth);
+            // Select the most appropriate distance the scalebar should cover.
+            const displayDistance = controller.calculateBestScalebarLength(maxDistance);
+            // Calculate the new displayed scalebar width.
+            internal.displayWidth = controller.calculateDisplayWidth(displayDistance, maxDistance, availableWidth);
+            // Display the value of the calculated distance.
+            internal.displayDistance = controller.calculateDistanceInDisplayUnits(displayDistance, controller.unitSystem);
+        }
+
+        property Connections geoViewConnections: Connections {
+            target: controller.mapView
+            function onViewpointChanged() {
+                internal.calculateScale();
+            }
+        }
+    }
+}

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/esri_arcgisruntime_toolkit_view.qrc
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/esri_arcgisruntime_toolkit_view.qrc
@@ -14,6 +14,8 @@
     <file>OverviewMap.qml</file>
     <file>PopupStackView.qml</file>
     <file>PopupView.qml</file>
+    <file>Scaleline.qml</file>
+    <file>ScalelineImpl.qml</file>
     <file>SslHandshakeView.qml</file>
     <file>TimeSlider.qml</file>
     <file>UserCredentialsView.qml</file>

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/qmldir
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/qmldir
@@ -32,6 +32,8 @@ OAuth2View 100.10 OAuth2View.qml
 OverviewMap 100.12 OverviewMap.qml
 PopupStackView 100.10 PopupStackView.qml
 PopupView 100.10 PopupView.qml
+Scaleline 100.13 Scaleline.qml
+internal ScalelineImpl ScalelineImpl.qml
 SslHandshakeView 100.10 SslHandshakeView.qml
 TimeSlider 100.10 TimeSlider.qml
 UserCredentialsView 100.10 UserCredentialsView.qml

--- a/uitools/register/Esri/ArcGISRuntime/Toolkit/internal/register_cpp.cpp
+++ b/uitools/register/Esri/ArcGISRuntime/Toolkit/internal/register_cpp.cpp
@@ -25,6 +25,7 @@
 #include "NorthArrowController.h"
 #include "OverviewMapController.h"
 #include "PopupViewController.h"
+#include "ScalelineController.h"
 #include "TimeSliderController.h"
 
 // Internal includes
@@ -56,7 +57,7 @@ const QString ESRI_COM_PATH = QStringLiteral(":/esri.com/imports");
 constexpr char const* NAMESPACE = "Esri.ArcGISRuntime.Toolkit.Controller";
 
 constexpr int VERSION_MAJOR = 100;
-constexpr int VERSION_MINOR = 12;
+constexpr int VERSION_MINOR = 13;
 
 /*
  \internal
@@ -108,6 +109,7 @@ void registerComponents_cpp_(QQmlEngine& appEngine)
   registerComponent<NorthArrowController>(10);
   registerComponent<OverviewMapController>(12);
   registerComponent<PopupViewController>(10);
+  registerComponent<ScalelineController>(13);
   registerComponent<TimeSliderController>(10);
 
   // Register ArcGISRuntime types with toolkit.


### PR DESCRIPTION
Apologies I couldn't finish this in Sprint X, so I will be spinning up some follow-on tasks to finish this implementaton.

This is a Scaleline implementation for Qt Quick C++ ONLY. 

 Styling the scale-line is not possible. But the user can choose between metric/imperial units. 
