### PR TITLE
Update Show Popup sample UI

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
@@ -1,3 +1,5 @@
+
+
 /*******************************************************************************
  *  Copyright 2012-2020 Esri
  *
@@ -13,10 +15,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  ******************************************************************************/
-
 import QtQuick 2.11
 import QtQuick.Controls 2.4
 import QtQuick.Layouts 1.12
+
 
 /*!
    \qmltype PopupStackView
@@ -26,16 +28,16 @@ import QtQuick.Layouts 1.12
    \since Esri.ArcGISRuntime 100.10
    \brief A view for displaying and editing information of GeoElements,
    including Features and Graphics.
-   
+
    A PopupStackView can be used to display information for any type that
    implements the PopupSource interface. For example, FeatureLayer
    implements PopupSource. This means that it has a PopupDefinition,
    which defines how the Popup should look for any features in that
    layer.
-   
+
    An example workflow for displaying a PopupStackView for features in a
    FeatureLayer would be:
-   
+
    \list
      \li Declare a PopupStackView and anchor it to a desired location.
      \li Perform an identify operation on a GeoView and select the desired
@@ -43,20 +45,20 @@ import QtQuick.Layouts 1.12
      \li Create Popups from the Features.
      \li Optionally obtain the Popup's PopupDefinition and set the
      title, whether to show attachments, and so on.
-     \li Create a PopupManager from the Popup and add it to a list of 
+     \li Create a PopupManager from the Popup and add it to a list of
      PopupManagers
      \li Assign the list mentioned in the above step to the PopupStackView's
      \c popupManagers property
    \endlist
-   
+
    The PopupStackView is a QML Item that can be anchored, given to a dialog,
    or positioned using XY screen coordinates. Transform, Transition, and
    other QML animation types can be used to animate the showing and
    dismissing of the view.
-   
+
    For more information, please see the Popup and PopupManager
    documentation.
-   
+
    \note Each time a change is made to the Popup, PopupDefinition,
    PopupManager, or any of their properties, the popupManagers must be
    re-set to the PopupStackView.
@@ -64,12 +66,14 @@ import QtQuick.Layouts 1.12
 Control {
     id: popupStackView
 
+
     /*!
-       \brief A list of PopupManagers that controls the information being 
+       \brief A list of PopupManagers that controls the information being
        displayed in a PopupStackView.
        \qmlproperty list<PopupManager> popupManagers
      */
     property var popupManagers: null
+
 
     /*!
        \brief This property holds the current top-most item in the stack. I.E.
@@ -79,13 +83,15 @@ Control {
      */
     property alias currentItem: stack.currentItem
 
+
     /*!
-       \brief This property holds the number of items currently pushed onto the 
+       \brief This property holds the number of items currently pushed onto the
        stack.
        \qmlproperty int depth
        \sa {https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html}{StackView}
      */
     property alias depth: stack.depth
+
 
     /*!
        \brief This property holds whether a transition is running.
@@ -94,37 +100,42 @@ Control {
      */
     property alias busy: stack.busy
 
+
     /*!
-      \brief This property holds the transition that is applied to the item 
+      \brief This property holds the transition that is applied to the item
       that enters the stack when another item is popped off of it.
       \qmlproperty Transition popEnter
       \sa {https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html}{StackView}
      */
     property alias popEnter: stack.popEnter
 
+
     /*!
-       \brief This property holds the transition that is applied to the item 
+       \brief This property holds the transition that is applied to the item
        that exits the stack when the item is popped off of it.
        \qmlproperty Transition popExit
        \sa {https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html}{StackView}
      */
     property alias popExit: stack.popExit
 
+
     /*!
-       \brief This property holds the transition that is applied to the item 
+       \brief This property holds the transition that is applied to the item
        that enters the stack when the item is pushed onto it.
        \qmlproperty Transition pushEnter
        \sa {https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html}{StackView}
      */
     property alias pushEnter: stack.pushEnter
 
+
     /*!
-       \brief This property holds the transition that is applied to the item 
+       \brief This property holds the transition that is applied to the item
        that exits the stack when another item is pushed onto it.
        \qmlproperty Transition pushExit
        \sa {https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html}{StackView}
      */
     property alias pushExit: stack.pushExit
+
 
     /*!
        \brief Callback function called when the close button is clicked. When
@@ -132,9 +143,10 @@ Control {
        the close button is clicked the function in this property is called.
        Defaults to setting visible to false.
      */
-    property var closeCallback: function() {
-        popupStackView.visible = false;
+    property var closeCallback: function () {
+        popupStackView.visible = false
     }
+
 
     /*!
        \qmlsignal PopupStackView::attachmentThumbnailClicked(int index)
@@ -144,76 +156,82 @@ Control {
      */
     signal attachmentThumbnailClicked(var index)
 
+
     /*!
        \brief Removes all items from the stack.
        \a args all args passed
        \sa {https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html}{StackView}
      */
     function clear(...args) {
-        return stack.clear(...args);
+        return stack.clear(...args)
     }
+
 
     /*!
        \brief Search for a specific item inside the stack. The callback function
-       is called for each item in the stack (with the item and index as 
+       is called for each item in the stack (with the item and index as
        arguments) until the callback function returns true. The return value is
        the item found.
        \a args all args passed
        \sa {https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html}{StackView}
      */
     function find(...args) {
-        return stack.find(...args);
+        return stack.find(...args)
     }
 
+
     /*!
-       \brief Returns the item at position index in the stack, or null if the 
+       \brief Returns the item at position index in the stack, or null if the
        index is out of bounds.
        \a args all args passed
        \sa {https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html}{StackView}
      */
     function get(...args) {
-        return stack.get(...args);
+        return stack.get(...args)
     }
-    
+
+
     /*!
-       \brief Pops one or more items off the stack. Returns the last item 
+       \brief Pops one or more items off the stack. Returns the last item
        removed from the stack. If the item argument is specified, all items down
-       to (but not including) item will be popped. If item is null, all items 
-       down to (but not including) the first item is popped. If not specified, 
+       to (but not including) item will be popped. If item is null, all items
+       down to (but not including) the first item is popped. If not specified,
        only the current item is popped.
        \a args all args passed
        \sa {https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html}{StackView}
      */
     function pop(...args) {
-        return stack.pop(...args);
+        return stack.pop(...args)
     }
 
+
     /*!
-       \brief Attempts to show the previous item in the list of 
+       \brief Attempts to show the previous item in the list of
        PopupManagers.
      */
     function gotoPrevious() {
-        stack.pop();
+        stack.pop()
     }
 
+
     /*!
-       \brief Attempts to show the next item in the list of 
+       \brief Attempts to show the next item in the list of
        PopupManagers.
      */
     function gotoNext() {
-        // We want a transition on show, so we force the first item to 
+        // We want a transition on show, so we force the first item to
         // transition.
-        stack.push(popupViewPage, StackView.PushTransition);
-    } 
+        stack.push(popupViewPage, StackView.PushTransition)
+    }
 
     onVisibleChanged: {
         // Always display with a transition and on page 1.
         if (visible) {
-            clear();
-            gotoNext();
+            clear()
+            gotoNext()
         }
     }
-    
+
     clip: true
 
     implicitWidth: 300 + padding
@@ -238,25 +256,12 @@ Control {
             margins: 5
         }
 
-        Button {
-            text: "Previous"
-            onClicked: gotoPrevious();
-            Layout.alignment: Qt.AlignLeft
-            enabled: popupManagers ? stack.depth > 1 : false
-        }
-
         Text {
             Layout.fillWidth: true
-            horizontalAlignment: Text.AlignHCenter
-            text: popupManagers && popupManagers.length > 0 ? `${stack.depth} of ${popupManagers.length}` : ""
+            horizontalAlignment: Text.AlignRight
+            text: popupManagers
+                  && popupManagers.length > 0 ? `${stack.depth} of ${popupManagers.length}` : ""
             color: palette.text
-        }
-
-        Button {
-            text: "Next"
-            onClicked: gotoNext();
-            Layout.alignment: Qt.AlignRight
-            enabled: popupManagers ? stack.depth < popupManagers.length : false
         }
 
         StackView {
@@ -269,12 +274,13 @@ Control {
         Component {
             id: popupViewPage
             PopupView {
-                popupManager: popupManagers && popupManagers.length >= StackView.index ? popupManagers[StackView.index] : null
+                popupManager: popupManagers && popupManagers.length
+                              >= StackView.index ? popupManagers[StackView.index] : null
                 palette: popupStackView.palette
                 background: null
                 closeCallback: popupStackView.closeCallback
                 onAttachmentThumbnailClicked: {
-                    popupStackView.attachmentThumbnailClicked(index);
+                    popupStackView.attachmentThumbnailClicked(index)
                 }
             }
         }

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
@@ -1,5 +1,3 @@
-
-
 /*******************************************************************************
  *  Copyright 2012-2020 Esri
  *
@@ -143,7 +141,7 @@ Control {
        the close button is clicked the function in this property is called.
        Defaults to setting visible to false.
      */
-    property var closeCallback: function () {
+    property var closeCallback: function() {
         popupStackView.visible = false;
     }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
@@ -278,7 +278,7 @@ Control {
                 background: null
                 closeCallback: popupStackView.closeCallback
                 onAttachmentThumbnailClicked: {
-                    popupStackView.attachmentThumbnailClicked(index)
+                    popupStackView.attachmentThumbnailClicked(index);
                 }
             }
         }

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
@@ -144,7 +144,7 @@ Control {
        Defaults to setting visible to false.
      */
     property var closeCallback: function () {
-        popupStackView.visible = false
+        popupStackView.visible = false;
     }
 
 
@@ -163,7 +163,7 @@ Control {
        \sa {https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html}{StackView}
      */
     function clear(...args) {
-        return stack.clear(...args)
+        return stack.clear(...args);
     }
 
 
@@ -176,7 +176,7 @@ Control {
        \sa {https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html}{StackView}
      */
     function find(...args) {
-        return stack.find(...args)
+        return stack.find(...args);
     }
 
 
@@ -187,7 +187,7 @@ Control {
        \sa {https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html}{StackView}
      */
     function get(...args) {
-        return stack.get(...args)
+        return stack.get(...args);
     }
 
 
@@ -201,7 +201,7 @@ Control {
        \sa {https://doc.qt.io/qt-5/qml-qtquick-controls2-stackview.html}{StackView}
      */
     function pop(...args) {
-        return stack.pop(...args)
+        return stack.pop(...args);
     }
 
 
@@ -210,7 +210,7 @@ Control {
        PopupManagers.
      */
     function gotoPrevious() {
-        stack.pop()
+        stack.pop();
     }
 
 
@@ -221,14 +221,14 @@ Control {
     function gotoNext() {
         // We want a transition on show, so we force the first item to
         // transition.
-        stack.push(popupViewPage, StackView.PushTransition)
+        stack.push(popupViewPage, StackView.PushTransition);
     }
 
     onVisibleChanged: {
         // Always display with a transition and on page 1.
         if (visible) {
-            clear()
-            gotoNext()
+            clear();
+            gotoNext();
         }
     }
 
@@ -259,8 +259,7 @@ Control {
         Text {
             Layout.fillWidth: true
             horizontalAlignment: Text.AlignRight
-            text: popupManagers
-                  && popupManagers.length > 0 ? `${stack.depth} of ${popupManagers.length}` : ""
+            text: popupManagers && popupManagers.length > 0 ? `${stack.depth} of ${popupManagers.length}` : ""
             color: palette.text
         }
 
@@ -274,8 +273,7 @@ Control {
         Component {
             id: popupViewPage
             PopupView {
-                popupManager: popupManagers && popupManagers.length
-                              >= StackView.index ? popupManagers[StackView.index] : null
+                popupManager: popupManagers && popupManagers.length >= StackView.index ? popupManagers[StackView.index] : null
                 palette: popupStackView.palette
                 background: null
                 closeCallback: popupStackView.closeCallback

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -90,7 +90,7 @@ Control {
        Defaults to setting visible to false.
      */
     property var closeCallback: function () {
-        popupView.visible = false
+        popupView.visible = false;
     }
 
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -1,3 +1,5 @@
+
+
 /*******************************************************************************
  *  Copyright 2012-2020 Esri
  *
@@ -22,6 +24,7 @@ import QtQuick.Dialogs 1.2
 import QtQuick.Window 2.11
 import QtQuick.Layouts 1.3
 
+
 /*!
    \qmltype PopupView
    \ingroup ArcGISQtToolkit
@@ -29,7 +32,7 @@ import QtQuick.Layouts 1.3
    \inqmlmodule Esri.ArcGISRuntime.Toolkit
    \since Esri.ArcGISRuntime 100.10
    \brief A view for displaying and editing information about a feature.
-  
+
    A PopupView can be used to display information for any type that
    implements the PopupSource interface. For example, FeatureLayer
    implements PopupSource. This means that it has a PopupDefinition,
@@ -61,21 +64,24 @@ import QtQuick.Layouts 1.3
 Control {
     id: popupView
 
+
     /*!
        \brief The PopupManager that controls the information being displayed in
        the view.
-       
+
        The PopupManager should be created from a Popup.
        \qmlproperty PopupManager popupManager
      */
     property var popupManager: null
-    
+
+
     /*!
       \qmlproperty PopupViewController controller
       \brief the Controller handles reading from the PopupManager and monitoring
       the list-models.
     */
-    property var controller: PopupViewController { }
+    property var controller: PopupViewController {}
+
 
     /*!
        \brief Callback function called when the close button is clicked. When
@@ -83,9 +89,10 @@ Control {
        the close button is clicked the function in this property is called.
        Defaults to setting visible to false.
      */
-    property var closeCallback: function() {
-        popupView.visible = false;
+    property var closeCallback: function () {
+        popupView.visible = false
     }
+
 
     /*!
        \qmlsignal PopupView::attachmentThumbnailClicked(var index)
@@ -129,8 +136,8 @@ Control {
             }
 
             // We must account for what is visible, including title headers as rows.
-            rows: controller.showAttachments ? controller.fieldCount + controller.attachmentCount + 2
-                                             : controller.fieldCount + 1
+            rows: controller.showAttachments ? controller.fieldCount + controller.attachmentCount
+                                               + 1 : controller.fieldCount
 
             // Title Header
             Text {
@@ -177,15 +184,6 @@ Control {
                 }
             }
 
-            Button {
-                text: "Close"
-                Layout.alignment: Qt.AlignRight
-                onClicked: {
-                    if (popupView.closeCallback)
-                        popupView.closeCallback();
-                }
-            }
-
             // Field contents
             Repeater {
                 model: controller.displayFields
@@ -217,5 +215,14 @@ Control {
             }
         }
     }
-}
 
+    Button {
+        text: "Close"
+        anchors.centerIn: parent
+
+        onClicked: {
+            if (popupView.closeCallback)
+                popupView.closeCallback()
+        }
+    }
+}

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -1,5 +1,3 @@
-
-
 /*******************************************************************************
  *  Copyright 2012-2020 Esri
  *
@@ -136,8 +134,8 @@ Control {
             }
 
             // We must account for what is visible, including title headers as rows.
-            rows: controller.showAttachments ? controller.fieldCount + controller.attachmentCount
-                                               + 1 : controller.fieldCount
+            rows: controller.showAttachments ? controller.fieldCount + controller.attachmentCount + 1
+                                             : controller.fieldCount
 
             // Title Header
             Text {

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -89,7 +89,7 @@ Control {
        the close button is clicked the function in this property is called.
        Defaults to setting visible to false.
      */
-    property var closeCallback: function () {
+    property var closeCallback: function() {
         popupView.visible = false;
     }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -144,6 +144,7 @@ Control {
                 Layout.fillWidth: true
                 textFormat: Text.StyledText
                 text: `<h2>${controller.title}</h2>`
+                wrapMode: Text.Wrap
                 color: palette.text
                 font: popupView.font
             }


### PR DESCRIPTION
This pull request updates the existing show popup sample. Currently the sample has "next" and "previous" buttons that are not functional and are always greyed out. Additionally, the "Close" button used to close the popup covered the title so I moved it to the bottom of the popup and it no longer covers any text. 

Supplement PR in the SDK samples repo: 

Please let me know if I should assign anyone else to review.

**Old UI:**

![old_UI](https://user-images.githubusercontent.com/3746552/134216993-dc07d7ff-cb0f-4dda-89af-44f521df8ef2.png)

**New UI:**

![popup_new_UI](https://user-images.githubusercontent.com/3746552/134220564-d4e8d767-49d4-4a13-96f0-700dc30b5abc.PNG)

