### PR TITLE
Incl. buttons when results > 1; adjust close bttn

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupStackView.qml
@@ -254,11 +254,28 @@ Control {
             margins: 5
         }
 
+        Button {
+            text: "Previous"
+            onClicked: gotoPrevious();
+            Layout.alignment: Qt.AlignLeft
+            visible: popupManagers && popupManagers.length > 1
+            enabled: popupManagers ? stack.depth > 1 : false
+        }
+
         Text {
             Layout.fillWidth: true
-            horizontalAlignment: Text.AlignRight
+            Layout.columnSpan: popupManagers && popupManagers.length > 1 ? 1 : 3
+            horizontalAlignment: Text.AlignHCenter
             text: popupManagers && popupManagers.length > 0 ? `${stack.depth} of ${popupManagers.length}` : ""
             color: palette.text
+        }
+
+        Button {
+            text: "Next"
+            onClicked: gotoNext();
+            Layout.alignment: Qt.AlignRight
+            visible: popupManagers && popupManagers.length > 1
+            enabled: popupManagers ? stack.depth < popupManagers.length : false
         }
 
         StackView {

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -213,15 +213,20 @@ Control {
                 }
             }
         }
-    }
 
-    Button {
-        text: "Close"
-        anchors.centerIn: parent
+        Button {
+            anchors {
+                top: fieldsLayout.bottom
+                topMargin: 20
+                horizontalCenter: parent.horizontalCenter
+            }
+            Layout.alignment: Qt.AlignHCenter
+            text: "Close"
 
-        onClicked: {
-            if (popupView.closeCallback)
-                popupView.closeCallback()
+            onClicked: {
+                if (popupView.closeCallback)
+                    popupView.closeCallback()
+            }
         }
     }
 }


### PR DESCRIPTION
Enables previous/next buttons when results > 1. Spans 3 grid columns when results <= 1. Adjusts anchors for the close buttons.