### PR TITLE
set the implicit width and height to 32

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
@@ -27,7 +27,7 @@ import QtQuick 2.12
    heading of the SceneView. 
    Double clicking on the NorthArrow triggers the heading of the connected
    GeoView to be orientainted to 0.
-   \note default width and height is 32.
+   \note default width and height is 48.
  */
 
 Item {

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
@@ -52,7 +52,7 @@ Item {
     */
     property var controller: NorthArrowController { }
 
-    implicitWidth: 32
+    implicitWidth: 48
 
     implicitHeight: implicitWidth
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
@@ -27,6 +27,7 @@ import QtQuick 2.12
    heading of the SceneView. 
    Double clicking on the NorthArrow triggers the heading of the connected
    GeoView to be orientainted to 0.
+   \note default width and height is 32.
  */
 
 Item {
@@ -50,6 +51,10 @@ Item {
       \brief the Controller handles connections writing/reading to the GeoView.
     */
     property var controller: NorthArrowController { }
+
+    implicitWidth: 32
+
+    implicitHeight: implicitWidth
 
     Binding {
         target: controller


### PR DESCRIPTION
fix to default height and width were 0. set to 32
it might be too small 32x32
![image](https://user-images.githubusercontent.com/91129623/134535639-678b0377-a411-4d4f-ac2d-11562c0b906f.png)
