### PR TITLE
Andrewbladon/basemap gallery set basemap fix

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BasemapGalleryController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BasemapGalleryController.qml
@@ -216,7 +216,7 @@ QtObject {
                 }
             }
         }
-        property Connections geoModelConenctions: Connections {
+        property Connections geoModelConnections: Connections {
             target: geoModel
             function onBasemapChanged() {
                 internal.currentBasemap = geoModel.basemap;

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BasemapGalleryController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BasemapGalleryController.qml
@@ -92,9 +92,9 @@ QtObject {
      */
     function setGeoModelFromGeoView(view) {
         if (view instanceof SceneView) {
-            setCurrentBasemap(view.scene);
+            setCurrentBasemap(view.scene ? view.scene.basemap : null);
         } else if (view instanceof MapView) {
-            setCurrentBasemap(view.map);
+            setCurrentBasemap(view.map ? view.map.basemap : null);
         }
     }
 


### PR DESCRIPTION
This PR adds a check to see if the Scene/Map view has been initialised prior to passing an argument into the setBasemap() method. If the Scene/Map view has been initialised, this is passed as an argument. If the view has not been initialised, null is passed as an argument.

A misspelling of "connections" in geoModelConnections has also been resolved.

@anmacdonald, please could you review these minor changes?