### PR TITLE
northarrow set default initial size

### DIFF
--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/NorthArrow.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/NorthArrow.cpp
@@ -53,7 +53,7 @@ NorthArrow::NorthArrow(QWidget* parent) :
   QLabel(parent),
   m_controller(new NorthArrowController(this))
 {
-  m_image = QPixmap(":/esri.com/imports/Esri/ArcGISRuntime/Tookit/images/compass.png");
+  m_image = QPixmap(":/esri.com/imports/Esri/ArcGISRuntime/Toolkit/images/compass.png");
 
   if (!m_image.isNull())
   {


### PR DESCRIPTION
setting hardcoded 48x48 default size for the png for the compass. even if the png will be changed to a diffent size, it will be initially resized to 48x48