### PR TITLE
default size widget northarrow

### DIFF
--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/NorthArrow.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/NorthArrow.cpp
@@ -53,7 +53,7 @@ NorthArrow::NorthArrow(QWidget* parent) :
   QLabel(parent),
   m_controller(new NorthArrowController(this))
 {
-  m_image = QPixmap(":/esri.com/imports/Esri/ArcGISRuntime/Tookit/images/compass.png");
+  m_image = QPixmap(":/esri.com/imports/Esri/ArcGISRuntime/Toolkit/images/compass.png");
 
   if (!m_image.isNull())
   {

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/NorthArrow.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/NorthArrow.cpp
@@ -42,6 +42,7 @@ namespace Toolkit
   \c Camera heading of the \c SceneView. 
   Double-clicking on the \c NorthArrow triggers the heading of the connected
   \c GeoView to be orientated to 0 (North).
+  \note default width and height is 48.
  */
 
 /*!

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/NorthArrow.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/NorthArrow.cpp
@@ -25,6 +25,7 @@
 // Qt headers
 #include <QMouseEvent>
 
+
 namespace Esri
 {
 namespace ArcGISRuntime
@@ -57,7 +58,8 @@ NorthArrow::NorthArrow(QWidget* parent) :
 
   if (!m_image.isNull())
   {
-    this->setPixmap(m_image);
+    const QSize defaultSize(48,48);
+    this->setPixmap(m_image.scaled(defaultSize, Qt::IgnoreAspectRatio));
   }
 
   connect(m_controller, &NorthArrowController::headingChanged, this, [this]()


### PR DESCRIPTION
setting also for the widget qt northarrow an inital size as 48x48. if the png is changed later on, the size will still be 48x48