### PR TITLE
BasemapGallery tooltips: enable links and adjust timing

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
@@ -246,6 +246,34 @@ Pane {
                 anchors.fill: parent
                 hoverEnabled: true
                 onClicked: controller.setCurrentBasemap(modelData.basemap)
+
+                // When mouse enters thumbnail area, use timer to delay showing of tooltip.
+                onEntered: {
+                    timerOnEntered.start();
+                }
+                // When mouse exits thumbnail area, use timer to delay hiding of tooltip.
+                onExited: {
+                    timerOnExited.start();
+                }
+
+                Timer {
+                    id: timerOnEntered
+                    interval: 1000
+                    repeat: false
+                    onTriggered: {
+                        if (allowTooltips && mouseArea.containsMouse && modelData.tooltip !== "")
+                            basemapDelegate.ToolTip.visible = true;
+                    }
+                }
+
+                Timer {
+                    id: timerOnExited
+                    interval: 1000
+                    repeat: false
+                    onTriggered: {
+                        basemapDelegate.ToolTip.visible = false;
+                    }
+                }
             }
         }
         highlightFollowsCurrentItem: false

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
@@ -202,7 +202,9 @@ Pane {
             Connections {
                 target: basemapDelegate.ToolTip.toolTip.contentItem
                 enabled: basemapDelegate.ToolTip.visible
-                function onLinkActivated(link){Qt.openUrlExternally(link)}
+                function onLinkActivated(link){
+                    Qt.openUrlExternally(link)
+                }
             }
             ToolTip.text: modelData.tooltip
 
@@ -248,17 +250,17 @@ Pane {
                 onClicked: controller.setCurrentBasemap(modelData.basemap)
 
                 // When mouse enters thumbnail area, use timer to delay showing of tooltip.
-                onEntered: {
-                    timerOnEntered.start();
-                }
+                onEntered: timerOnEntered.start();
+
                 // When mouse exits thumbnail area, use timer to delay hiding of tooltip.
                 onExited: {
+                    timerOnEntered.stop();
                     timerOnExited.start();
                 }
 
                 Timer {
                     id: timerOnEntered
-                    interval: 1000
+                    interval: Qt.styleHints.mousePressAndHoldInterval * 2
                     repeat: false
                     onTriggered: {
                         if (allowTooltips && mouseArea.containsMouse && modelData.tooltip !== "")
@@ -268,11 +270,9 @@ Pane {
 
                 Timer {
                     id: timerOnExited
-                    interval: 1000
+                    interval: Qt.styleHints.mousePressAndHoldInterval * 1.9
                     repeat: false
-                    onTriggered: {
-                        basemapDelegate.ToolTip.visible = false;
-                    }
+                    onTriggered: basemapDelegate.ToolTip.visible = false;
                 }
             }
         }

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
@@ -202,7 +202,7 @@ Pane {
             Connections {
                 target: basemapDelegate.ToolTip.toolTip.contentItem
                 enabled: basemapDelegate.ToolTip.visible
-                function onLinkActivated(link){
+                function onLinkActivated(link) {
                     Qt.openUrlExternally(link)
                 }
             }
@@ -289,7 +289,10 @@ Pane {
 
         interval: Qt.styleHints.mousePressAndHoldInterval * 2
         repeat: false
-        onTriggered: showTooltipFn();
+        onTriggered: {
+            if (showTooltipFn)
+                showTooltipFn();
+        }
     }
 
     Timer {
@@ -299,7 +302,10 @@ Pane {
 
         interval: Qt.styleHints.mousePressAndHoldInterval * 1.9
         repeat: false
-        onTriggered: hideTooltipFn();
+        onTriggered: {
+            if (hideTooltipFn())
+                hideTooltipFn();
+        }
     }
 
     property QtObject internal: QtObject {

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
@@ -195,12 +195,17 @@ Pane {
         currentIndex: controller.basemapIndex(controller.currentBasemap)
         ScrollBar.vertical: ScrollBar { }
         delegate: Item {
+            id: basemapDelegate
             width: view.cellWidth
             height: view.cellHeight
             enabled: controller.basemapMatchesCurrentSpatialReference(modelData.basemap)
-            ToolTip.visible: allowTooltips && mouseArea.containsMouse && modelData.tooltip !== ""
-            ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval * 2
-            ToolTip.text: modelData.tooltip.replace(/(<([^>]+)>)/ig," ").replace(/\s+/g," ")    // html tags removed using regex (links dont work in tooltips)
+            Connections {
+                target: basemapDelegate.ToolTip.toolTip.contentItem
+                enabled: basemapDelegate.ToolTip.visible
+                function onLinkActivated(link){Qt.openUrlExternally(link)}
+            }
+            ToolTip.text: modelData.tooltip
+
             GridLayout {
                 anchors.fill: parent
                 anchors.margins: 8

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
@@ -250,29 +250,23 @@ Pane {
                 onClicked: controller.setCurrentBasemap(modelData.basemap)
 
                 // When mouse enters thumbnail area, use timer to delay showing of tooltip.
-                onEntered: timerOnEntered.start();
+                onEntered: {
+                    // Create a definition for the showTooltipFn property of timerOnEntered
+                    timerOnEntered.showTooltipFn = () => {
+                        if (allowTooltips && mouseArea.containsMouse && modelData.tooltip !== "")
+                            basemapDelegate.ToolTip.visible = true;
+                    }
+                    timerOnEntered.start();
+                }
 
                 // When mouse exits thumbnail area, use timer to delay hiding of tooltip.
                 onExited: {
                     timerOnEntered.stop();
-                    timerOnExited.start();
-                }
-
-                Timer {
-                    id: timerOnEntered
-                    interval: Qt.styleHints.mousePressAndHoldInterval * 2
-                    repeat: false
-                    onTriggered: {
-                        if (allowTooltips && mouseArea.containsMouse && modelData.tooltip !== "")
-                            basemapDelegate.ToolTip.visible = true;
+                    // Create a definition for the hideTooltipFn property of timerOnExited
+                    timerOnExited.hideTooltipFn = () => {
+                        basemapDelegate.ToolTip.visible = false;
                     }
-                }
-
-                Timer {
-                    id: timerOnExited
-                    interval: Qt.styleHints.mousePressAndHoldInterval * 1.9
-                    repeat: false
-                    onTriggered: basemapDelegate.ToolTip.visible = false;
+                    timerOnExited.start();
                 }
             }
         }
@@ -286,6 +280,26 @@ Pane {
             color: palette.highlight
             radius: 5
         }
+    }
+
+    Timer {
+        id: timerOnEntered
+
+        property var showTooltipFn: null;
+
+        interval: Qt.styleHints.mousePressAndHoldInterval * 2
+        repeat: false
+        onTriggered: showTooltipFn();
+    }
+
+    Timer {
+        id: timerOnExited
+
+        property var hideTooltipFn: null;
+
+        interval: Qt.styleHints.mousePressAndHoldInterval * 1.9
+        repeat: false
+        onTriggered: hideTooltipFn();
     }
 
     property QtObject internal: QtObject {

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
@@ -200,7 +200,7 @@ Pane {
             enabled: controller.basemapMatchesCurrentSpatialReference(modelData.basemap)
             ToolTip.visible: allowTooltips && mouseArea.containsMouse && modelData.tooltip !== ""
             ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval * 2
-            ToolTip.text: modelData.tooltip
+            ToolTip.text: modelData.tooltip.replace(/(<([^>]+)>)/ig," ").replace(/\s+/g," ")    // html tags removed using regex (links dont work in tooltips)
             GridLayout {
                 anchors.fill: parent
                 anchors.margins: 8


### PR DESCRIPTION
Html links included in tooltip's in the Basemap Gallery cannot be clicked. This PR adds a parser to remove any html tags [e.g. `<html>` and `</html>`] from tooltip text. This means the text appears as plain text and does not appear as a link.