### PR TITLE
Add onLoadStatusChanged to TimeSliderController

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/TimeSliderController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/TimeSliderController.qml
@@ -185,6 +185,12 @@ QtObject {
             function onOperationalLayersChanged() {
                 internal.initializeTimeProperties();
             }
+
+            function onLoadStatusChanged() {
+                if ((geoView.scene ?? geoView.map).loadStatus !== Enums.LoadStatusLoaded)
+                    return;
+                internal.initializeTimeProperties();
+            }
         }
 
         // Grabs the operational layers from the geoview.


### PR DESCRIPTION
This fix addresses a bug where the time slider in QML does not refresh when the time extent changes.