### PR TITLE
Remove brackets from hideTooltipFn null check

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
@@ -303,7 +303,7 @@ Pane {
         interval: Qt.styleHints.mousePressAndHoldInterval * 1.9
         repeat: false
         onTriggered: {
-            if (hideTooltipFn())
+            if (hideTooltipFn)
                 hideTooltipFn();
         }
     }


### PR DESCRIPTION
This PR removes the brackets from `hideTooltipFn()` in a null check expression.

@anmacdonald, please could you confirm that the null check is now correct? Thanks.