### PR TITLE
Cache timeExtent prior to assigning to geoView

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/TimeSliderController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/TimeSliderController.qml
@@ -147,8 +147,10 @@ QtObject {
         const startMS = extent.startTime.getTime();
         const s = new Date(startMS + startStep * intervalMS);
         const e = new Date(startMS + endStep * intervalMS);
-        geoView.timeExtent = ArcGISRuntimeEnvironment.createObject(
+        const timeExtent = ArcGISRuntimeEnvironment.createObject(
                     "TimeExtent", { startTime: s, endTime: e });
+                    
+        geoView.timeExtent = timeExtent;            
         stepsChanged();
     }
 


### PR DESCRIPTION
This change addresses a bug in the QML toolkit where the map does not redraw as we step through the time aware data using the play button.

This is a work around for a known existing JS bug.