### PR TITLE
Ensure Overview Map updates at initialisation to be consistent with geoView

### DIFF
--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/OverviewMapController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/OverviewMapController.cpp
@@ -137,7 +137,7 @@ namespace Toolkit {
                            applySceneNavigationToInset(sceneView);
                          }
                        });
-      // Create single-shot connection to geoView's drawStatusChanged to ensure OverviewMap updates when SceneView initially loads.
+      // Create single-shot connection to geoView's drawStatusChanged to ensure OverviewMap updates when the scene initially loads.
       QMetaObject::Connection* const sceneViewDrawStatusConnection = new QMetaObject::Connection;
       *sceneViewDrawStatusConnection = connect(sceneView, &SceneViewToolkit::drawStatusChanged, this,
                        [this, sceneView, sceneViewDrawStatusConnection] (DrawStatus status)
@@ -169,7 +169,7 @@ namespace Toolkit {
                            applyMapNavigationToInset(mapView);
                          }
                        });
-      // Create single-shot connection to geoView's drawStatusChanged to ensure OverviewMap updates when MapView initially loads.
+      // Create single-shot connection to geoView's drawStatusChanged to ensure OverviewMap updates when the map initially loads.
       QMetaObject::Connection* const mapViewDrawStatusConnection = new QMetaObject::Connection;
       *mapViewDrawStatusConnection = connect(mapView, &MapViewToolkit::drawStatusChanged, this,
                                   [this, mapView, mapViewDrawStatusConnection](DrawStatus status)

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/OverviewMapController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/OverviewMapController.cpp
@@ -137,6 +137,17 @@ namespace Toolkit {
                            applySceneNavigationToInset(sceneView);
                          }
                        });
+      // Create single-shot connection to geoView's drawStatusChanged to ensure OverviewMap updates when SceneView initially loads.
+      QMetaObject::Connection* const sceneViewDrawStatusConnection = new QMetaObject::Connection;
+      *sceneViewDrawStatusConnection = connect(sceneView, &SceneViewToolkit::drawStatusChanged, this,
+                       [this, sceneView, sceneViewDrawStatusConnection] (DrawStatus status)
+                       {
+                          if (status == DrawStatus::Completed)
+                            applySceneNavigationToInset(sceneView);
+
+                          QObject::disconnect(*sceneViewDrawStatusConnection);
+                          delete sceneViewDrawStatusConnection;
+                        });
     }
     else if (auto mapView = qobject_cast<MapViewToolkit*>(m_geoView))
     {
@@ -158,6 +169,17 @@ namespace Toolkit {
                            applyMapNavigationToInset(mapView);
                          }
                        });
+      // Create single-shot connection to geoView's drawStatusChanged to ensure OverviewMap updates when MapView initially loads.
+      QMetaObject::Connection* const mapViewDrawStatusConnection = new QMetaObject::Connection;
+      *mapViewDrawStatusConnection = connect(mapView, &MapViewToolkit::drawStatusChanged, this,
+                                  [this, mapView, mapViewDrawStatusConnection](DrawStatus status)
+                                  {
+                                    if (status == DrawStatus::Completed)
+                                      applyMapNavigationToInset(mapView);
+
+                                    QObject::disconnect(*mapViewDrawStatusConnection);
+                                    delete mapViewDrawStatusConnection;
+                                  });
     }
     emit geoViewChanged();
   }


### PR DESCRIPTION
Currently, the Overview Map toolkit component does not always display the desired view when an application starts. At initialisation, the Overview Map often displays a world view, while the geoView (MapView or SceneView) displays a local viewpoint. In order to get the Overview Map to show the desired overview, the user needs to interact with the geoView to force the Overview Map to update.

This PR adds single-shot connections to both the C++ and QML Overview Map Controller's. The connections respond to the `onDrawStatusChanged` signal and, if `DrawStatus` = completed, the viewpoint in the Overview Map will be updated. Once this has finished, the connection will be disconnected to prevent this happening multiple times.

@anmacdonald and @mrwillyees, please could you review these changes?