### PR TITLE
Example apps can now read an ENV variable to set the API key.

### DIFF
--- a/uitools/examples/cpp_quick/src/main.cpp
+++ b/uitools/examples/cpp_quick/src/main.cpp
@@ -31,67 +31,75 @@
 //------------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {
-    QtWebView::initialize();
-    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-    QGuiApplication app(argc, argv);
+  QtWebView::initialize();
+  QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+  QGuiApplication app(argc, argv);
 
-    // Use of Esri location services, including basemaps and geocoding, requires
-    // either an ArcGIS identity or an API key. For more information see
-    // https://links.esri.com/arcgis-runtime-security-auth.
+  // Use of Esri location services, including basemaps and geocoding, requires
+  // either an ArcGIS identity or an API key. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
 
-    // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-    // organization in ArcGIS Online or ArcGIS Enterprise.
+  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
 
-    // 2. API key: A permanent key that gives your application access to Esri
-    // location services. Create a new API key or access existing API keys from
-    // your ArcGIS for Developers dashboard (https://links.esri.com/arcgis-api-keys).
+  // 2. API key: A permanent key that gives your application access to Esri
+  // location services. Create a new API key or access existing API keys from
+  // your ArcGIS for Developers dashboard (https://links.esri.com/arcgis-api-keys).
 
-    const QString apiKey = QString("");
-    if (!apiKey.isEmpty()) {
-        Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
-    }
+  QString apiKey = QString("");
+  if (apiKey.isEmpty())
+  {
+    apiKey = qgetenv("ARCGIS_RUNTIME_API_KEY");
+  }
 
-    QQuickStyle::addStylePath("qrc:///esri.com/imports/");
+  if (!apiKey.isEmpty())
+  {
+    Esri::ArcGISRuntime::ArcGISRuntimeEnvironment::setApiKey(apiKey);
+  }
 
-    // Register ArcGIS types with QML.
-    qmlRegisterExtendedType<Esri::ArcGISRuntime::MapQuickView,
-                            MapQuickViewProxy>("Esri.ArcGISRuntime", 100, 13, "MapView");
-    qmlRegisterExtendedType<Esri::ArcGISRuntime::SceneQuickView,
-                            SceneQuickViewProxy>("Esri.ArcGISRuntime", 100, 13, "SceneView");
-    qmlRegisterUncreatableType<GeoModelProxy>("Esri.ArcGISRuntime",
-                                              100,
-                                              13,
-                                              "Map",
-                                              "Map not creatable in QML.");
-    qmlRegisterUncreatableType<GeoModelProxy>("Esri.ArcGISRuntime",
-                                              100,
-                                              13,
-                                              "Scene",
-                                              "Scene not creatable in QML.");
+  QQuickStyle::addStylePath("qrc:///esri.com/imports/");
 
-    qmlRegisterSingletonType<ArcGISRuntimeEnvironmentProxy>(
-        "Esri.ArcGISRuntime",
-        100,
-        13,
-        "ArcGISRuntimeEnvironment",
-        [](QQmlEngine *engine, QJSEngine *) -> QObject * {
-            return new ArcGISRuntimeEnvironmentProxy(engine);
-        });
+  // Register ArcGIS types with QML.
+  qmlRegisterExtendedType<Esri::ArcGISRuntime::MapQuickView,
+                          MapQuickViewProxy>("Esri.ArcGISRuntime", 100, 13, "MapView");
+  qmlRegisterExtendedType<Esri::ArcGISRuntime::SceneQuickView,
+                          SceneQuickViewProxy>("Esri.ArcGISRuntime", 100, 13, "SceneView");
+  qmlRegisterUncreatableType<GeoModelProxy>("Esri.ArcGISRuntime",
+                                            100,
+                                            13,
+                                            "Map",
+                                            "Map not creatable in QML.");
+  qmlRegisterUncreatableType<GeoModelProxy>("Esri.ArcGISRuntime",
+                                            100,
+                                            13,
+                                            "Scene",
+                                            "Scene not creatable in QML.");
 
-    qmlRegisterSingletonType<EnumsProxy>("Esri.ArcGISRuntime",
-                                         100,
-                                         13,
-                                         "Enums",
-                                         [](QQmlEngine *engine, QJSEngine *) -> QObject * {
-                                             return new EnumsProxy(engine);
-                                         });
+  qmlRegisterSingletonType<ArcGISRuntimeEnvironmentProxy>(
+      "Esri.ArcGISRuntime",
+      100,
+      13,
+      "ArcGISRuntimeEnvironment",
+      [](QQmlEngine* engine, QJSEngine*) -> QObject*
+      {
+        return new ArcGISRuntimeEnvironmentProxy(engine);
+      });
 
-    // Register Own types with QML.
-    // Initialize application view
-    QQmlApplicationEngine engine;
-    Esri::ArcGISRuntime::Toolkit::registerComponents(engine);
-    engine.load(QUrl("qrc:/demo_app/qml/main.qml"));
-    return app.exec();
+  qmlRegisterSingletonType<EnumsProxy>("Esri.ArcGISRuntime",
+                                       100,
+                                       13,
+                                       "Enums",
+                                       [](QQmlEngine* engine, QJSEngine*) -> QObject*
+                                       {
+                                         return new EnumsProxy(engine);
+                                       });
+
+  // Register Own types with QML.
+  // Initialize application view
+  QQmlApplicationEngine engine;
+  Esri::ArcGISRuntime::Toolkit::registerComponents(engine);
+  engine.load(QUrl("qrc:/demo_app/qml/main.qml"));
+  return app.exec();
 }
 
 //------------------------------------------------------------------------------

--- a/uitools/examples/qml_quick/src/main.cpp
+++ b/uitools/examples/qml_quick/src/main.cpp
@@ -27,21 +27,28 @@ int main(int argc, char* argv[])
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
     QGuiApplication app(argc, argv);
 
-    // Use of Esri location services, including basemaps and geocoding, requires
-    // either an ArcGIS identity or an API key. For more information see
-    // https://links.esri.com/arcgis-runtime-security-auth.
+  // Use of Esri location services, including basemaps and geocoding, requires
+  // either an ArcGIS identity or an API key. For more information see
+  // https://links.esri.com/arcgis-runtime-security-auth.
 
-    // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
-    // organization in ArcGIS Online or ArcGIS Enterprise.
+  // 1. ArcGIS identity: An ArcGIS named user account that is a member of an
+  // organization in ArcGIS Online or ArcGIS Enterprise.
 
-    // 2. API key: A permanent key that gives your application access to Esri
-    // location services. Create a new API key or access existing API keys from
-    // your ArcGIS for Developers dashboard (https://links.esri.com/arcgis-api-keys).
+  // 2. API key: A permanent key that gives your application access to Esri
+  // location services. Create a new API key or access existing API keys from
+  // your ArcGIS for Developers dashboard (https://links.esri.com/arcgis-api-keys).
 
-    const QString apiKey = QString("");
-    if (!apiKey.isEmpty()) {
-        QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
+  QString apiKey = QString("");
+  if (apiKey.isEmpty())
+  {
+    apiKey = qgetenv("ARCGIS_RUNTIME_API_KEY");
   }
+
+  if (!apiKey.isEmpty())
+  {
+    QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.apiKey", apiKey);
+  }
+
 
   QQuickStyle::addStylePath("qrc:///esri.com/imports/");
 


### PR DESCRIPTION
As discussed, added a configuration to read the API Key from the environment if not explicitly set.

Ran the formatter which edited the file moree than I expected. Sorry about that.