### PR TITLE
Fixed the rowcount and columnspan of the popupview.

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -128,11 +128,12 @@ Pane {
             }
 
             // We must account for what is visible, including title headers as rows.
-            rows: controller.showAttachments ? controller.fieldCount + controller.attachmentCount + 1
-                                             : controller.fieldCount
+            rows: controller.showAttachments ? controller.fieldCount + controller.attachmentCount + 2
+                                             : controller.fieldCount + 1
 
             // Title Header
             Label {
+                Layout.columnSpan: 2
                 Layout.fillWidth: true
                 textFormat: Text.StyledText
                 text: `<h2>${controller.title}</h2>`
@@ -145,7 +146,7 @@ Pane {
                 model: controller.displayFields
                 Label {
                     Layout.fillWidth: true
-                    text: fieldName ? fieldName : ""
+                    text: fieldName ?? ""
                     wrapMode: Text.WrapAnywhere
                 }
             }

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -128,8 +128,8 @@ Pane {
             }
 
             // We must account for what is visible, including title headers as rows.
-            rows: controller.showAttachments ? controller.fieldCount + controller.attachmentCount + 2
-                                             : controller.fieldCount + 1
+            rows: controller.showAttachments ? controller.fieldCount + controller.attachmentCount + 3
+                                             : controller.fieldCount + 2
 
             // Title Header
             Label {
@@ -174,6 +174,16 @@ Pane {
                 }
             }
 
+            Button {
+                Layout.columnSpan: 2
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
+                text: "Close"
+                onClicked: {
+                    if (popupView.closeCallback)
+                        popupView.closeCallback()
+                }
+            }
+
             // Field contents
             Repeater {
                 model: controller.displayFields
@@ -201,20 +211,6 @@ Pane {
                         }
                     }
                 }
-            }
-        }
-
-        Button {
-            anchors {
-                top: fieldsLayout.bottom
-                horizontalCenter: parent.horizontalCenter
-                topMargin: popupView.spacing
-            }
-            text: "Close"
-
-            onClicked: {
-                if (popupView.closeCallback)
-                    popupView.closeCallback()
             }
         }
     }


### PR DESCRIPTION
Fixes break caused by https://github.com/Esri/arcgis-runtime-toolkit-qt/pull/438/files

Effectively, the close button was removed from the content of the Popup, but the Label wasn't set to span two columns, this made everything go out of order with respect to the attachments.