### PR TITLE
Change Qml Overview Map insetView property type

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/OverviewMapController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/OverviewMapController.qml
@@ -75,7 +75,7 @@ QtObject {
       \qmlproperty MapView insetView
       \brief MapView which represents an overview/inset of the current viewpoint of the geoView.
      */
-    readonly property MapView insetView: MapView {
+    readonly property var insetView: MapView {
         // Default map to show in the inset.
         Map {
             initBasemapStyle: Enums.BasemapStyleArcGISTopographic


### PR DESCRIPTION
This PR changes the insetView property type from `MapView` to `var`. This change was made in response to issues reported while testing the Qml version of the Display overview Map sample on Android.

***NOTE:*** Initial testing comprised the Qml sample viewer being built and deployed onto an android emulator - the issue was reproduced and these changes fixed the issue. However, while following these steps a second time during re-testing the original issue could not be reproduced.