### PR TITLE
Adding rotating functionality for the qml example

### DIFF
--- a/uitools/examples/qml_quick/src/demos/NorthArrowDemoForm.qml
+++ b/uitools/examples/qml_quick/src/demos/NorthArrowDemoForm.qml
@@ -46,6 +46,7 @@ DemoPage {
                     bottom: parent.attributionTop
                 }
             }
+            rotationByPinchingEnabled: true
         }
 //! [Set up North Arrow QML]
     }


### PR DESCRIPTION
Adding rotating functionality for the qml example 2D.
The 3D pinching works without any amendments. 