### PR TITLE
Removing line that triggers bug in CMake's automoc.

### DIFF
--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/Internal/GenericListModel.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/Internal/GenericListModel.cpp
@@ -43,10 +43,9 @@ namespace Toolkit {
  \code
  class Foo : public QObject
  {
-   Q_OBJECT
    Q_PROPERTY(int propertyA READ propertyA WRITE setPropertyA NOTIFY propertyAChanged)
    Q_PROPERTY(QString propertyB READ propertyB NOTIFY propertyBChanged)
-   Q_PROPERTY(bool propertyC READ propertyC CONTANT)
+   Q_PROPERTY(bool propertyC READ propertyC CONSTANT)
  };
  \endcode
 


### PR DESCRIPTION
Fixes https://github.com/Esri/arcgis-runtime-toolkit-qt/issues/492

`Q_OBJECT` in a comment triggers a bug in CMake where `moc` is run on a file.

There is no harm removing this line. It does not detract from the comment's content, and it will help anyone who might be trying a CMake build. 

This also future-proofs ourselves when we move to CMake in the future.
