### PR TITLE
using groupfilters to hide and show no result found delegate.

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/FloorFilterController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/FloorFilterController.qml
@@ -48,9 +48,19 @@ QtObject {
 
     property ListModel levels: ListModel {}
 
-    property ListModel facilities: ListModel {}
+    property ListModel facilities: ListModel {
+        ListElement {
+            name: ""
+            modelId: ""
+        }
+    }
 
-    property ListModel sites: ListModel {}
+    property ListModel sites: ListModel {
+        ListElement {
+            name: ""
+            modelId: ""
+        }
+    }
 
     property alias selectedSite: internal.selectedSite
     property alias selectedFacility: internal.selectedFacility

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
@@ -272,12 +272,26 @@ Control {
                                         item.inFiltered = false
                                 }
                             }
+
+                            // toggling the inFilter group on the default item noResultFound, to toggle its visibility
+                            if (filteredGroup.count === 0) {
+                                console.log("setting noresult")
+                                noResultsFound.get(0).inFiltered = true
+                            } else
+                                noResultsFound.get(0).inFiltered = false
                         }
                     }
 
                     model: internal.currentVisibileListView
                            === FloorFilter.VisibleListView.Site ? controller.sites : controller.facilities
-                    Component.onCompleted: console.log("count:", count)
+                    Component.onCompleted: {
+                        // creating the default text item. only shown when no filtered items are found
+                        noResultsFound.insert(0, {
+                                                  "name": "No results found"
+                                              })
+                        var item = noResultsFound.get(0)
+                    }
+
                     onCountChanged: console.log("count:", count)
                     filterOnGroup: "filtered"
                     groups: [
@@ -285,10 +299,18 @@ Control {
                             id: filteredGroup
                             name: "filtered"
                             includeByDefault: true
+                        },
+                        DelegateModelGroup {
+                            id: noResultsFound
+                            name: "noResultsFound"
+                            includeByDefault: false
                         }
                     ]
                     delegate: RadioDelegate {
-                        Component.onCompleted: console.log("delegate", height)
+                        Component.onCompleted: {
+                            if (DelegateModel.inNoResultsFound)
+                                this.enabled = false
+                        }
                         width: listView.width
                         highlighted: internal.currentVisibileListView
                                      === FloorFilter.VisibleListView.Site ? index === internal.selectedSiteIdx : index === internal.selectedFacilityIdx


### PR DESCRIPTION
the item "no results found" is part of the listview and it is shown or hidden using the group filtering functionality provided by the `DelegateModel`. This item is not part of the `controller.model`, but it is stored in the `DelegateModelGroup.name == noResultsFound`.


clicking on show all facilities needs fix because the temporary no resuilts found is still shown.

Any better solution in your opinion?