### PR TITLE
Floorfilter/tooltip

### DIFF
--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterController.cpp
@@ -189,6 +189,7 @@ namespace Toolkit {
   {
     m_sites->setDisplayPropertyName("name");
     m_facilities->setDisplayPropertyName("name");
+    m_facilities->setTooltipPropertyName("parentSiteName");
     m_levels->setDisplayPropertyName("longName");
 
     connect(this, &FloorFilterController::selectedFacilityIdChanged, this, &FloorFilterController::selectedChanged);
@@ -330,7 +331,6 @@ namespace Toolkit {
   {
     if (m_selectedFacilityId == selectedFacilityId)
       return;
-
     QString oldId = m_selectedFacilityId;
     m_selectedFacilityId = std::move(selectedFacilityId);
     emit selectedFacilityIdChanged(std::move(oldId), m_selectedFacilityId);
@@ -475,7 +475,6 @@ namespace Toolkit {
 
     m_facilities->clear();
     m_facilities->append(facilityItems);
-
     // Select only facility if there is only 1 facility.
     if (facilityItems.size() == 1)
     {

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterController.cpp
@@ -386,7 +386,7 @@ namespace Toolkit {
   /*!
    \internal
    \brief Clears the levels list, and repopulates with only those levels
-   thaat match the ecurrently selected site id. Levels are sorted in terms
+   that match the currently selected site id. Levels are sorted in terms
    of their vertical order, and a default level is selected, favouring the
    level with verticalOrder == 0.
    */
@@ -437,7 +437,7 @@ namespace Toolkit {
    \brief Clears the facilities list and repopulates with the facilites that have a matching
    siteID to \l selectedSiteId.
 
-   If only on faciity exists we select that facility, otherwise we do not automatically select
+   If only on facility exists we select that facility, otherwise we do not automatically select
    a facility.
 
    Note that `sites` are optional in the data, and it may be the case that ther are no sites,
@@ -563,7 +563,7 @@ namespace Toolkit {
   }
 
   /*!
-   \brief On the GeoView, zooms to the facility with ID matching \a siteId.
+   \brief On the GeoView, zooms to the site with ID matching \a siteId.
    */
   void FloorFilterController::zoomToSite(const QString& siteId)
   {
@@ -721,7 +721,7 @@ namespace Toolkit {
 
   /*!
    * \internal
-   * \brief Attempts to select a facility based on the current viewpoint geoemtry.
+   * \brief Attempts to select a facility based on the current viewpoint geometry.
    */
   void FloorFilterController::tryUpdateSelection()
   {

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterFacilityItem.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterFacilityItem.cpp
@@ -17,6 +17,7 @@
 
 // ArcGISRuntime headers
 #include <FloorFacility.h>
+#include <FloorSite.h>
 
 namespace Esri {
 namespace ArcGISRuntime {
@@ -88,6 +89,11 @@ namespace Toolkit {
   QString FloorFilterFacilityItem::name() const
   {
     return m_floorFacility ? m_floorFacility->name() : QString{};
+  }
+
+  QString FloorFilterFacilityItem::parentSiteName() const
+  {
+    return m_floorFacility ? m_floorFacility->site()->name() : QString{};
   }
 
   /*!

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterFacilityItem.h
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterFacilityItem.h
@@ -29,6 +29,7 @@ namespace ArcGISRuntime {
       Q_OBJECT
       Q_PROPERTY(QString modelId READ modelId NOTIFY floorFacilityChanged)
       Q_PROPERTY(QString name READ name NOTIFY floorFacilityChanged)
+      Q_PROPERTY(QString parentSiteName READ parentSiteName NOTIFY floorFacilityChanged)
     public:
       Q_INVOKABLE explicit FloorFilterFacilityItem(QObject* parent = nullptr);
       Q_INVOKABLE explicit FloorFilterFacilityItem(FloorFacility* floorFacility, QObject* parent = nullptr);
@@ -39,6 +40,7 @@ namespace ArcGISRuntime {
 
       QString modelId() const;
       QString name() const;
+      QString parentSiteName() const;
 
     signals:
       void floorFacilityChanged();

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
@@ -58,7 +58,7 @@ Pane {
     }
 
     /*!
-      \qmlproperty BasemapGalleryController controller.
+      \qmlproperty BasemapGalleryController controller
       \brief The controller handles binding logic between the BasemapGallery and
       the \c GeoModel and the \c Portal where applicable.
     */

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BasemapGalleryController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BasemapGalleryController.qml
@@ -20,7 +20,7 @@ import QtQml.Models 2.15
 /*!
    \qmltype BasemapGalleryController
    \inqmlmodule Esri.ArcGISRuntime.Toolkit
-   \since Esri.ArcGISRutime 100.12
+   \since Esri.ArcGISRuntime 100.12
    \ingroup ArcGISQtToolkitUiQmlControllers
    \brief The controller part of a BasemapGallery. This class handles the
    management of the BasemapGalleryItem objects, and listening to changes to the current

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
@@ -26,7 +26,6 @@ import QtGraphicalEffects 1.12
   \ingroup ArcGISQtToolkitUiQmlViews
   \since 100.14
   \brief Allows to display and filter the available floor aware layers in the current \c GeoMap.
-
   The FloorFilter allows the interaction with the available floor aware layers. A user can select from a list of sites which presents
   their facilities. Once a facility is chosen, it is possible to toggle between its levels which will show them on the \c GeoView.
   2D maps and 3D scenes are supported.
@@ -46,13 +45,14 @@ Control {
       \qmlproperty FloorFilterController controller
       \brief The controller handles biding logic between the FloorFilter and the \c GeoModel, \c FloorManager and
       its flooraware layers.
-      Defaults to \l{FloorFilterController}
+      Default is \l{FloorFilterController}
     */
     property var controller: FloorFilterController {}
 
     /*!
       \qmlproperty int updateLevelsMode
       \brief The mode to use for updating levels visibility.
+      \sa FloorFilterController.updateLevelsMode
     */
     property int updateLevelsMode: controller.updateLevelsMode
 
@@ -61,6 +61,8 @@ Control {
     /*!
       \qmlproperty int automaticSelectionMode
       \brief The mode to use for the automatic selection of levels based on current center viewpoint.
+      Defaults is \c{FloorFilterController.AutomaticSelectionMode.Always}.
+      \sa FloorFilterController.automaticSelection
 
 
     */


### PR DESCRIPTION
showing tooltip in widget FloorFilter. This change also fixes the `allSites` for the cpp version, which uses the model `tooltip()` and shows it in the newline when clicking `allSites`.
![image](https://user-images.githubusercontent.com/91129623/157251553-1a1841fd-c379-41a8-b777-d01895a1b6b5.png)
