### PR TITLE
Hiding popup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * (SpinBox) Calcite styling of the SpinBox component.
 * (Callout) Major rewrite of Callout. Moved from Canvas to Shape rendering. Callout is now style compliant.
 * Adding unit and functional test suites for uitools.
+* (PopupView) Setting `closeCallback` to `null` now correctly hides the close button as docs advertise.
 
 ## 100.13
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -221,6 +221,7 @@ Page {
     }
 
     footer: ColumnLayout {
+        visible: popupView.closeCallback
         Button {
             text: "Close"
             Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter


### PR DESCRIPTION
When `popupView.closeCallback = null`, then we set the close-button footer to invisible. This is as the docs advertise.