### PR TITLE
fix racecondition/early delete of connection

### DIFF
--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterController.cpp
@@ -828,10 +828,10 @@ namespace Toolkit {
     EnvelopeBuilder b{envelope};
     b.expandByFactor(ZOOM_PADDING);
 
+    auto c = std::make_shared<QMetaObject::Connection>();
     if (auto mapView = qobject_cast<MapViewToolkit*>(m_geoView))
     {
       m_settingViewpoint = true;
-      auto c = std::make_shared<QMetaObject::Connection>();
       *c = connect(mapView, &MapViewToolkit::setViewpointCompleted, this, [this, c](bool success)
                    {
                      if (success)
@@ -845,10 +845,14 @@ namespace Toolkit {
     else if (auto sceneView = qobject_cast<SceneViewToolkit*>(m_geoView))
     {
       m_settingViewpoint = true;
-      singleShotConnection(sceneView, &SceneViewToolkit::setViewpointCompleted, this, [this](bool /*success*/)
-                           {
-                             m_settingViewpoint = false;
-                           });
+      *c = connect(sceneView, &SceneViewToolkit::setViewpointCompleted, this, [this, c](bool success)
+                   {
+                     if (success)
+                     {
+                       m_settingViewpoint = false;
+                       disconnect(*c);
+                     }
+                   });
       sceneView->setViewpoint(b.toEnvelope());
     }
   }

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterController.cpp
@@ -278,12 +278,6 @@ namespace Toolkit {
                        {
                          populateSites();
                        });
-      //debug
-      assert(mapView != nullptr);
-      connect(mapView, &MapViewToolkit::setViewpointCompleted, this, [this](bool /*success*/)
-              {
-                qDebug() << "viewpoint compl;eted";
-              });
     }
     else if (auto sceneView = qobject_cast<SceneViewToolkit*>(m_geoView))
     {
@@ -512,7 +506,6 @@ namespace Toolkit {
     if (!facilityItem)
       return;
 
-    qDebug() << "zoom to facility";
     const auto f = facilityItem->floorFacility();
     if (f)
     {
@@ -525,7 +518,6 @@ namespace Toolkit {
    */
   void FloorFilterController::zoomToFacility(const QString& facilityId)
   {
-    qDebug() << "zoom to facility";
     zoomToFacility(facility(facilityId));
   }
 
@@ -536,7 +528,6 @@ namespace Toolkit {
   {
     if (!siteItem)
       return;
-    qDebug() << "zoom to site";
     const auto s = siteItem->floorSite();
     if (s)
     {
@@ -549,7 +540,6 @@ namespace Toolkit {
    */
   void FloorFilterController::zoomToSite(const QString& siteId)
   {
-    qDebug() << "zoom to site";
     zoomToSite(site(siteId));
   }
 
@@ -708,7 +698,6 @@ namespace Toolkit {
    */
   void FloorFilterController::tryUpdateSelection()
   {
-    qDebug() << "tryupadte, " << m_settingViewpoint;
     if (m_automaticSelectionMode == AutomaticSelectionMode::Never)
       return;
 
@@ -841,31 +830,16 @@ namespace Toolkit {
 
     if (auto mapView = qobject_cast<MapViewToolkit*>(m_geoView))
     {
-      qDebug() << "setting viewpoint flag true";
       m_settingViewpoint = true;
       auto c = std::make_shared<QMetaObject::Connection>();
       *c = connect(mapView, &MapViewToolkit::setViewpointCompleted, this, [this, c](bool success)
                    {
                      if (success)
                      {
-                       qDebug() << "setting false";
                        m_settingViewpoint = false;
                        disconnect(*c);
                      }
                    });
-      //      singleShotConnection(mapView, &MapViewToolkit::setViewpointCompleted, this, [this, mapView](bool success)
-      //                           {
-      //                             qDebug() << success;
-      //                             if (!mapView->isNavigating())
-      //                             {
-      //                               qDebug() << "setting false";
-      //                               m_settingViewpoint = false;
-      //                             }
-      //                           });
-      //      if (mapView->isNavigating())
-      //      {
-      //        singleShotConnection(mapView, &)
-      //      }
       mapView->setViewpoint(b.toEnvelope());
     }
     else if (auto sceneView = qobject_cast<SceneViewToolkit*>(m_geoView))

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterController.cpp
@@ -828,9 +828,9 @@ namespace Toolkit {
     EnvelopeBuilder b{envelope};
     b.expandByFactor(ZOOM_PADDING);
 
-    auto c = std::make_shared<QMetaObject::Connection>();
     if (auto mapView = qobject_cast<MapViewToolkit*>(m_geoView))
     {
+      auto c = std::make_shared<QMetaObject::Connection>();
       m_settingViewpoint = true;
       *c = connect(mapView, &MapViewToolkit::setViewpointCompleted, this, [this, c](bool success)
                    {
@@ -844,6 +844,7 @@ namespace Toolkit {
     }
     else if (auto sceneView = qobject_cast<SceneViewToolkit*>(m_geoView))
     {
+      auto c = std::make_shared<QMetaObject::Connection>();
       m_settingViewpoint = true;
       *c = connect(sceneView, &SceneViewToolkit::setViewpointCompleted, this, [this, c](bool success)
                    {


### PR DESCRIPTION
Problem: when selecting a facility from the list `allSites`, it would zoom in and out immediately.
Figured out that the `singleShotConnection` in `zoomToEnvelope`, would run and then delete the connection without taking into account of the success of the setting of viewpoint. We are quickly calling `setViewpoint` for a facility and its parent site, but the second call is most likely called while the  first `setViewpoint` is still in progress. This triggers the `setViewpointCompleted` with `success == false`. In the previous code, we would then set the `m_settingViewpoint == false`, letting the `tryUpdate` to work. Problematically, this is done before the second `setViewpointCompleted` is done, so the `tryUpdate` starts evaluating the viewpoint caused from the `zoomToEnvelope`. Big nono, fixed with a traditional singleshotconnection but taking into account of the success!
Have a look if we can clean it please!
TODO: do the same for the sceneView