### PR TITLE
added Default link to controller and removed last period

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/AuthenticationView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/AuthenticationView.qml
@@ -58,10 +58,10 @@ Item {
 
     /*!
       \qmlproperty AuthenticationController controller
-      \brief the Controller handles references to challenges emitted by the
+      \brief The Controller handles references to challenges emitted by the
       \c AuthenticationManager.
 
-      A default \l AuthenticationController is provided.
+      A QML default is provided \l AuthenticationController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::AuthenticationController}{AuthenticationController}.
     */
     property var controller: AuthenticationController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/AuthenticationView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/AuthenticationView.qml
@@ -57,9 +57,11 @@ Item {
     id: authenticationView
 
     /*!
-      \qmlproperty AuthenticationController controller.
+      \qmlproperty AuthenticationController controller
       \brief the Controller handles references to challenges emitted by the
       \c AuthenticationManager.
+
+      A default \l AuthenticationController is provided.
     */
     property var controller: AuthenticationController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/AuthenticationView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/AuthenticationView.qml
@@ -61,7 +61,7 @@ Item {
       \brief The Controller handles references to challenges emitted by the
       \c AuthenticationManager.
 
-      A QML default is provided \l AuthenticationController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::AuthenticationController}{AuthenticationController}.
+      The QML controller is documented \l{AuthenticationController}{here} and the CPP controller is documented \l{Esri::ArcGISRuntime::Toolkit::AuthenticationController}{here}.
     */
     property var controller: AuthenticationController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
@@ -61,6 +61,8 @@ Pane {
       \qmlproperty BasemapGalleryController controller
       \brief The controller handles binding logic between the BasemapGallery and
       the \c GeoModel and the \c Portal where applicable.
+      
+      A QML default is provided \l BasemapGalleryController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::BasemapGalleryController}{BasemapGalleryController}.
     */
     property var controller: BasemapGalleryController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/BasemapGallery.qml
@@ -62,7 +62,7 @@ Pane {
       \brief The controller handles binding logic between the BasemapGallery and
       the \c GeoModel and the \c Portal where applicable.
       
-      A QML default is provided \l BasemapGalleryController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::BasemapGalleryController}{BasemapGalleryController}.
+      The QML controller is documented \l{BasemapGalleryController}{here} and the CPP controller is documented \l{Esri::ArcGISRuntime::Toolkit::BasemapGalleryController}{here}.
     */
     property var controller: BasemapGalleryController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/ScalebarController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/ScalebarController.qml
@@ -26,7 +26,9 @@ import QtQml 2.12
 
     This controller object handles the Scalebar calculations for a Scalebar's width
     and display units, based on a given mapview and owning scalebar's bounds.
+    \note This controller has not been implemented yet for QML.
  */
+//todo: once implemented, add this file as a \l to the docs on scalebar.qml controller property. remove the \note above
 QtObject {
 
   property var mapView;

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/CoordinateConversion.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/CoordinateConversion.qml
@@ -66,11 +66,11 @@ Pane {
 
     /*!
       \qmlproperty CoordinateConversionController controller
-      \brief the Controller handles connections writing/reading to the GeoView,
+      \brief The Controller handles connections writing/reading to the GeoView,
       and maintaining our list of textual representations of a single point
       in multiple formats.
 
-      A default \l CoordinateConversionController is provided.
+      A QML default is provided \l CoordinateConversionController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::CoordinateConversionController}{CoordinateConversionController}.
     */
     property var controller: CoordinateConversionController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/CoordinateConversion.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/CoordinateConversion.qml
@@ -65,10 +65,12 @@ Pane {
     property var inputFormat: CoordinateConversionResult { }
 
     /*!
-      \qmlproperty CoordinateConversionController controller.
+      \qmlproperty CoordinateConversionController controller
       \brief the Controller handles connections writing/reading to the GeoView,
       and maintaining our list of textual representations of a single point
       in multiple formats.
+
+      A default \l CoordinateConversionController is provided.
     */
     property var controller: CoordinateConversionController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/CoordinateConversion.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/CoordinateConversion.qml
@@ -70,7 +70,7 @@ Pane {
       and maintaining our list of textual representations of a single point
       in multiple formats.
 
-      A QML default is provided \l CoordinateConversionController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::CoordinateConversionController}{CoordinateConversionController}.
+      The QML controller is documented \l{CoordinateConversionController}{here} and the CPP controller is documented \l{Esri::ArcGISRuntime::Toolkit::CoordinateConversionController}{here}.
     */
     property var controller: CoordinateConversionController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
@@ -55,7 +55,7 @@ Control {
       \brief The controller handles binding logic between the FloorFilter, \c GeoModel, \c FloorManager and
       the flooraware layers.
       
-      A QML default is provided \l FloorFilterController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::FloorFilterController}{FloorFilterController}.
+      The QML controller is documented \l{FloorFilterController}{here} and the CPP controller is documented \l{Esri::ArcGISRuntime::Toolkit::FloorFilterController}{here}.
     */
     property var controller: FloorFilterController {}
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
@@ -55,7 +55,7 @@ Control {
       \brief The controller handles binding logic between the FloorFilter, \c GeoModel, \c FloorManager and
       the flooraware layers.
       
-      A default \l FloorFilterController is provided.
+      A QML default is provided \l FloorFilterController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::FloorFilterController}{FloorFilterController}.
     */
     property var controller: FloorFilterController {}
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
@@ -54,7 +54,8 @@ Control {
       \qmlproperty FloorFilterController controller
       \brief The controller handles binding logic between the FloorFilter, \c GeoModel, \c FloorManager and
       the flooraware layers.
-      Default is \l{FloorFilterController}
+      
+      A default \l FloorFilterController is provided.
     */
     property var controller: FloorFilterController {}
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
@@ -51,9 +51,9 @@ Item {
 
     /*!
       \qmlproperty NorthArrowController controller
-      \brief the Controller handles connections writing/reading to the GeoView.
+      \brief The Controller handles connections writing/reading to the GeoView.
 
-      A default \l NorthArrowController is provided.
+      A QML default is provided \l NorthArrowController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::NorthArrowController}{NorthArrowController}.
     */
     property var controller: NorthArrowController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
@@ -52,6 +52,8 @@ Item {
     /*!
       \qmlproperty NorthArrowController controller
       \brief the Controller handles connections writing/reading to the GeoView.
+
+      A default \l NorthArrowController is provided.
     */
     property var controller: NorthArrowController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/NorthArrow.qml
@@ -53,7 +53,7 @@ Item {
       \qmlproperty NorthArrowController controller
       \brief The Controller handles connections writing/reading to the GeoView.
 
-      A QML default is provided \l NorthArrowController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::NorthArrowController}{NorthArrowController}.
+      The QML controller is documented \l{NorthArrowController}{here} and the CPP controller is documented \l{Esri::ArcGISRuntime::Toolkit::NorthArrowController}{here}.
     */
     property var controller: NorthArrowController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/OverviewMap.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/OverviewMap.qml
@@ -34,9 +34,11 @@ Item {
     id: overviewMap
 
     /*!
-      \qmlproperty OverviewMapController controller.
+      \qmlproperty OverviewMapController controller
       \brief The controller handles binding logic between the OverviewMap and
       the \c GeoView where applicable.
+
+      A default \l OverviewMapController is provided.
      */
     property var controller: OverviewMapController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/OverviewMap.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/OverviewMap.qml
@@ -38,7 +38,7 @@ Item {
       \brief The controller handles binding logic between the OverviewMap and
       the \c GeoView where applicable.
 
-      A QML default is provided \l OverviewMapController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::OverviewMapController}{OverviewMapController}.
+      The QML controller is documented \l{OverviewMapController}{here} and the CPP controller is documented \l{Esri::ArcGISRuntime::Toolkit::OverviewMapController}{here}.
      */
     property var controller: OverviewMapController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/OverviewMap.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/OverviewMap.qml
@@ -38,7 +38,7 @@ Item {
       \brief The controller handles binding logic between the OverviewMap and
       the \c GeoView where applicable.
 
-      A default \l OverviewMapController is provided.
+      A QML default is provided \l OverviewMapController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::OverviewMapController}{OverviewMapController}.
      */
     property var controller: OverviewMapController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -80,7 +80,7 @@ Page {
       \brief The Controller handles reading from the PopupManager and monitoring
       the list-models.
 
-      A QML default is provided \l PopupViewController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::PopupViewController}{PopupViewController}.
+      The QML controller is documented \l{PopupViewController}{here} and the CPP controller is documented \l{Esri::ArcGISRuntime::Toolkit::PopupViewController}{here}.
     */
     property var controller: PopupViewController {}
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -80,7 +80,7 @@ Page {
       \brief The Controller handles reading from the PopupManager and monitoring
       the list-models.
 
-      A default is \l PopupViewController is provided.
+      A QML default is provided \l PopupViewController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::PopupViewController}{PopupViewController}.
     */
     property var controller: PopupViewController {}
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/PopupView.qml
@@ -77,8 +77,10 @@ Page {
 
     /*!
       \qmlproperty PopupViewController controller
-      \brief the Controller handles reading from the PopupManager and monitoring
+      \brief The Controller handles reading from the PopupManager and monitoring
       the list-models.
+
+      A default is \l PopupViewController is provided.
     */
     property var controller: PopupViewController {}
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Scalebar.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Scalebar.qml
@@ -47,6 +47,8 @@ Control {
       \brief The controller portion of the Scalebar which handles
       distance calculations based on the visual properties of the given
       \l{mapView}.
+
+      A default is \l ScalebarController is provided.
      */
     property var controller: ScalebarController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Scalebar.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Scalebar.qml
@@ -48,7 +48,7 @@ Control {
       distance calculations based on the visual properties of the given
       \l{mapView}.
 
-      A CPP default is provided \l{Esri::ArcGISRuntime::Toolkit::ScalebarController}{ScalebarController}.
+      The CPP controller is documented \l{Esri::ArcGISRuntime::Toolkit::ScalebarController}{here}.
      */
     property var controller: ScalebarController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Scalebar.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Scalebar.qml
@@ -48,7 +48,7 @@ Control {
       distance calculations based on the visual properties of the given
       \l{mapView}.
 
-      A default is \l ScalebarController is provided.
+      A CPP default is provided \l{Esri::ArcGISRuntime::Toolkit::ScalebarController}{ScalebarController}.
      */
     property var controller: ScalebarController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/SearchView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/SearchView.qml
@@ -47,7 +47,7 @@ Pane {
       \brief The Controller which performs the search and manages
       the results/suggestions.
 
-       A QML default is provided \l SearchViewController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::SearchViewController}{SearchViewController}.
+       The QML controller is documented \l{SearchViewController}{here} and the CPP controller is documented \l{Esri::ArcGISRuntime::Toolkit::SearchViewController}{here}.
     */
     property var controller: SearchViewController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/SearchView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/SearchView.qml
@@ -47,7 +47,7 @@ Pane {
       \brief The Controller which performs the search and manages
       the results/suggestions.
 
-       A default \l SearchViewController is provided.
+       A QML default is provided \l SearchViewController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::SearchViewController}{SearchViewController}.
     */
     property var controller: SearchViewController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/SearchView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/SearchView.qml
@@ -47,7 +47,7 @@ Pane {
       \brief The Controller which performs the search and manages
       the results/suggestions.
 
-       A default SearchViewController is provided.
+       A default \l SearchViewController is provided.
     */
     property var controller: SearchViewController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
@@ -85,7 +85,7 @@ Pane {
       \brief The controller handles calculating steps and setting extents on the
        GeoView.
 
-       A default TimeSliderController is provided.
+       A default \l TimeSliderController is provided.
     */
     property var controller: TimeSliderController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
@@ -85,7 +85,7 @@ Pane {
       \brief The controller handles calculating steps and setting extents on the
        GeoView.
 
-       A default \l TimeSliderController is provided.
+       A QML default is provided \l TimeSliderController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::TimeSliderController}{TimeSliderController}.
     */
     property var controller: TimeSliderController { }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
@@ -85,7 +85,7 @@ Pane {
       \brief The controller handles calculating steps and setting extents on the
        GeoView.
 
-       A QML default is provided \l TimeSliderController and a CPP is provided \l{Esri::ArcGISRuntime::Toolkit::TimeSliderController}{TimeSliderController}.
+       The QML controller is documented \l{TimeSliderController}{here} and the CPP controller is documented \l{Esri::ArcGISRuntime::Toolkit::TimeSliderController}{here}.
     */
     property var controller: TimeSliderController { }
 


### PR DESCRIPTION
Removed the ending period `.` after controller, which was creating a new property in the docs because the qdoc `qmlproperty`  type is different from the coded property (`var`).
![image](https://user-images.githubusercontent.com/91129623/160667025-d47d371d-3e73-4681-b05e-26e70bb08595.png)
Also, I would like to give more visibility to the cpp controller which is not linked other than on QWidgets but we don't have all the tools implemented as QWidgets, so many controller are only reachable from searching. I was thinking to something like on the qml GUI:
```qml
/*!
* \qmlproperty NorthArrowController controller
* . . . 
* A QML default is provided \l [QML] {NorthArrowController} and a CPP is provided \l [CPP] {NorthArrowController}
*/
property var controller : NorthArrowController
```
But both the links are pointing to the qml implementation, seems that the cpp version is not visible in qml files!