### PR TITLE
Awilliams/timeslieder enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 100.14
-* (TimeSlider) Forward and backward buttons are not enabled while playing. Holding buttons, will continuously skipping forward or backwards. Time label wrapping for small screens and not overlapping behind the buttons.
+* (TimeSlider) Forward and backward buttons are not enabled while playing. Holding buttons, continuously skips forward or backwards. Time labels wrap into new line for small screens and don't overlap behind the buttons.
 * (ScrollBar) Calcite styling of the ScrollBar, not matching specific component.
 * (FloorFilter) Viewpoint selection mode implemented.
 * (FloorFilter) Introduction of new FloorFilter tool (C++/Quick, QML/Quick, Widget) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 100.14
+* (TimeSlider) Forward and backward buttons are not enabled while playing. Holding buttons, will continuously skipping forward or backwards. Time label wrapping for small screens and not overlapping behind the buttons.
 * (ScrollBar) Calcite styling of the ScrollBar, not matching specific component.
 * (FloorFilter) Viewpoint selection mode implemented.
 * (FloorFilter) Introduction of new FloorFilter tool (C++/Quick, QML/Quick, Widget) 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
@@ -201,9 +201,16 @@ Pane {
         Button {
             id: stepBackButton
             icon.source: "images/step_back.png"
-            enabled: (!startTimePinned || !endTimePinned) && playAnimation.running
+            enabled: (!startTimePinned || !endTimePinned) && !playAnimation.running
             palette: timeSlider.palette
-            onClicked: timeSlider.incrementFrame(-1);
+            Timer {
+                id: pressedHoldBack
+                repeat: true
+                running: parent.pressed
+                interval: 200
+                onTriggered: timeSlider.incrementFrame(-1);
+                triggeredOnStart: true
+            }
             Layout.alignment: Qt.AlignLeft
             Layout.margins: 5
         }
@@ -231,7 +238,14 @@ Pane {
             icon.source: "images/step.png"
             enabled: (!startTimePinned || !endTimePinned) && !playAnimation.running
             palette: timeSlider.palette
-            onClicked: timeSlider.incrementFrame(1);
+            Timer {
+                id: pressedHoldForward
+                repeat: true
+                running: parent.pressed
+                interval: 200
+                onTriggered: timeSlider.incrementFrame(1);
+                triggeredOnStart: true
+            }
             Layout.alignment: Qt.AlignRight
             Layout.margins: 5
         }

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
@@ -201,7 +201,7 @@ Pane {
         Button {
             id: stepBackButton
             icon.source: "images/step_back.png"
-            enabled: !startTimePinned || !endTimePinned
+            enabled: (!startTimePinned || !endTimePinned) && playAnimation.running
             palette: timeSlider.palette
             onClicked: timeSlider.incrementFrame(-1);
             Layout.alignment: Qt.AlignLeft
@@ -229,7 +229,7 @@ Pane {
         Button {
             id: stepForwardButton
             icon.source: "images/step.png"
-            enabled: !startTimePinned || !endTimePinned
+            enabled: (!startTimePinned || !endTimePinned) && !playAnimation.running
             palette: timeSlider.palette
             onClicked: timeSlider.incrementFrame(1);
             Layout.alignment: Qt.AlignRight

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/TimeSlider.qml
@@ -196,6 +196,9 @@ Pane {
             Layout.alignment: Qt.AlignLeft | Qt.AlignBottom
             Layout.fillWidth: true
             Layout.margins: 5
+            wrapMode: Text.WordWrap
+            clip: true
+            maximumLineCount: 3
         }
 
         Button {
@@ -259,6 +262,9 @@ Pane {
             Layout.alignment: Qt.AlignRight  | Qt.AlignBottom
             Layout.fillWidth: true
             Layout.margins: 5
+            wrapMode: Text.WordWrap
+            clip: true
+            maximumLineCount: 3
         }
 
         Control {


### PR DESCRIPTION
implemented the enhancement requested for timeslider:
-  Disable forward and rewind buttons when in play
-  Allow press and hold on forward and rewind buttons to skip until released

removed onClick trigger and replaced with the timer running immediately the first time and only after 200ms keep running as it is hold. I tested and it feels all good, no weird behavior 