### PR TITLE
Fixing callout width/height calculations.

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
@@ -365,8 +365,8 @@ Pane {
             Layout.columnSpan: 3
             Layout.rowSpan: 2
             Layout.fillWidth: true
-            Layout.fillHeight: true
-            Layout.preferredWidth: root.maxWidth
+            Layout.preferredWidth: autoAdjustWidth ? -1 : root.maxWidth
+            Layout.maximumWidth: autoAdjustWidth ? root.maxWidth : -1
             visible: calloutContent
         }
         Image {


### PR DESCRIPTION
Making changes to `Callout` with a custom component. 

The height is no longer `fillHeight: true`, which means the callout sets the component width, and the component sets the callout height. This seems closer to the flow of width/height calculations used previously.


