### PR TITLE
Adding required  lines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 100.14
+* `toolkitwidgets.pri`, `toolkitqml.pri`, and `toolkitcpp.pri` now include `QT += ...` lines to account for needed dependencies.
 * (TimeSlider) Forward and backward buttons are not enabled while playing. Holding buttons, continuously skips forward or backwards. Time labels wrap into new line for small screens and don't overlap behind the buttons.
 * (ScrollBar) Calcite styling of the ScrollBar, not matching specific component.
 * (FloorFilter) Viewpoint selection mode implemented.

--- a/uitools/examples/cpp_quick/cpp_quick.pro
+++ b/uitools/examples/cpp_quick/cpp_quick.pro
@@ -16,11 +16,7 @@ TEMPLATE = app
 CONFIG += c++14 qmltypes
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick quickcontrols2 webview
-
-ios {
-    QT += svg
-}
+QT += opengl qml quick
 
 QML_IMPORT_NAME = "DemoApp"
 QML_IMPORT_MAJOR_VERSION = 1

--- a/uitools/examples/qml_quick/qml_quick.pro
+++ b/uitools/examples/qml_quick/qml_quick.pro
@@ -20,11 +20,7 @@ mac {
 CONFIG += c++14
 
 # additional modules are pulled in via arcgisruntime.pri
-QT += opengl qml quick quickcontrols2 webview
-
-ios {
-    QT += svg
-}
+QT += opengl qml quick
 
 ARCGIS_RUNTIME_VERSION = 100.14
 include($$PWD/arcgisruntime.pri)

--- a/uitools/toolkitcpp.pri
+++ b/uitools/toolkitcpp.pri
@@ -13,6 +13,8 @@
 # limitations under the License.
 include($$PWD/common.pri)
 
+QT += quickcontrols2 webview svg
+
 REGISTERPATH = $$PWD/register/Esri/ArcGISRuntime/Toolkit
 
 INCLUDEPATH += $$PWD/register $$REGISTERPATH

--- a/uitools/toolkitqml.pri
+++ b/uitools/toolkitqml.pri
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+QT += quickcontrols2 webview svg
+
 REGISTERPATH = $$PWD/register/Esri/ArcGISRuntime/Toolkit
 
 INCLUDEPATH += $$PWD/register $$REGISTERPATH

--- a/uitools/toolkitwidgets.pri
+++ b/uitools/toolkitwidgets.pri
@@ -13,6 +13,8 @@
 # limitations under the License.
 include($$PWD/common.pri)
 
+QT += widgets webenginewidgets svg
+
 RESOURCES += $$PWD/images/esri_arcgisruntime_toolkit_images.qrc
 
 DEFINES += WIDGETS_ARCGISRUNTIME_TOOLKIT


### PR DESCRIPTION
Toolkit, like ArcGIS, includes it's own required `QT +=` dependencies. The most important of which are `webview` for AuthenticationView, and `svg` for icon rendering. 