### PR TITLE
Tweaking DialogButtonBox.

### DIFF
--- a/calcite-qml/Calcite/DialogButtonBox.qml
+++ b/calcite-qml/Calcite/DialogButtonBox.qml
@@ -26,12 +26,9 @@ T.DialogButtonBox {
 
     spacing: 5
     padding: 16
-    buttonLayout: DialogButtonBox.MacLayout
     delegate: Button { }
 
     contentItem: ListView {
-          implicitWidth: parent.width
-          implicitHeight: 40
           model: control.contentModel
           spacing: control.spacing
           orientation: ListView.Horizontal
@@ -40,6 +37,11 @@ T.DialogButtonBox {
       }
 
         background: Rectangle {
+            implicitHeight: 60
+            x: 2.5
+            y: 2.5
+            width: parent.width - 5
+            height: parent.height - 5
             border {
                 width: 1
                 color: Calcite.border1


### PR DESCRIPTION
Some tweaks to DialogButtonBox. If you compare to Materials style DialogButtonBox this is more in line with how they have written theirs out.

1. This is to suppress the "implicitWidth biding loop detected" warning
2. Added some padding around the background.
3. ButtonLayout is no longer forced to Mac layout as default.