### PR TITLE
Marking calloutContent as obsolete.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 100.15
 
+* (Callout) Deprecated `calloutContent` property in favour of `contentItem` usage.
 * Updated `.png` files to be `.svg` instead. Tools no longer look pixilated on high-dpi devices.
 * (NorthArrow) Fixed deprecation warning in widgets.
 * (CoordinateConversion) Fixed button images not rendering.

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Callout.qml
@@ -157,9 +157,14 @@ Pane {
     property bool accessoryButtonVisible: true
 
     /*!
+        \obsolete
+
         \brief A QML Item to display in the Callout.
 
         The default is \c null.
+
+        This property is obsolete, to replace the Callout's content
+        set \c{contentItem} instead.
     */
     property Component calloutContent: null
 


### PR DESCRIPTION
Marking `calloutContent` as an obsolete property.