### PR TITLE
Update ScalebarController.qml

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/ScalebarController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/ScalebarController.qml
@@ -17,6 +17,7 @@
 import QtQml 2.12
 
 /*!
+   \internal
    \qmltype ScalineLineController
    \inqmlmodule Esri.ArcGISRuntime.Toolkit
    \since Esri.ArcGISRuntime 100.13


### PR DESCRIPTION
Per a user request, marking as internal for the time being. We only have C++ Qt Quick Scale Bar, and the QML controller is there only as a stub. Currently it shows up on the developer site even though it isn't implemented for QML API which is causing confusion

https://developers.arcgis.com/qt/toolkit/api-reference/qml-scalebarcontroller.html

@mfeigl please review.