### PR TITLE
Fixing Error: Cannot assign [undefined] to QUrl/QString

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BasemapGalleryController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/BasemapGalleryController.qml
@@ -127,8 +127,8 @@ QtObject {
                                         this,
                                         {
                                             basemap: basemap,
-                                            thumbnailUrlOverride: thumbnailUrl,
-                                            tooltipOverride: tooltip
+                                            thumbnailUrlOverride: thumbnailUrl ? thumbnailUrl : "",
+                                            tooltipOverride: tooltip ? tooltip : ""
                                         })
                     });
         return true;


### PR DESCRIPTION
The function `append(basemap, thumbnailUrl, tooltip)` is sometimes called with just a `basemap` provided as argument, which causes the `thumbnailUrl` and `tooltip` to be `undefined`.

This causes a massive wave of errors when running the tool. Fortunately, fixing it was simple enough. 

With this modification, the behavior did not change, but the errors all went away. 