### PR TITLE
Removing ColorOverlay as it's not supported in Qt6

### DIFF
--- a/calcite-qml/Calcite/CheckIndicator.qml
+++ b/calcite-qml/Calcite/CheckIndicator.qml
@@ -14,7 +14,6 @@
  *  limitations under the License.
  ******************************************************************************/
 import QtQuick
-import Qt5Compat.GraphicalEffects
 
 Rectangle {
     property var control;
@@ -36,13 +35,6 @@ Rectangle {
             margins: control.checkState === Qt.Checked ? -2 : 2
         }
         source: control.checkState === Qt.Checked ? "images/check.svg": "images/line-solid.svg"
-        visible: false
-    }
-
-    ColorOverlay {
-        anchors.fill: checkmark
-        source: checkmark
-        color: Calcite.textInverse
-        visible: control.checkState !== Qt.Unchecked
+        visible: true
     }
 }

--- a/calcite-qml/Calcite/CheckIndicator.qml
+++ b/calcite-qml/Calcite/CheckIndicator.qml
@@ -14,6 +14,7 @@
  *  limitations under the License.
  ******************************************************************************/
 import QtQuick
+import Qt5Compat.GraphicalEffects
 
 Rectangle {
     property var control;
@@ -36,5 +37,12 @@ Rectangle {
         }
         source: control.checkState === Qt.Checked ? "images/check.svg": "images/line-solid.svg"
         visible: false
+    }
+
+    ColorOverlay {
+        anchors.fill: checkmark
+        source: checkmark
+        color: Calcite.textInverse
+        visible: control.checkState !== Qt.Unchecked
     }
 }

--- a/calcite-qml/Calcite/CheckIndicator.qml
+++ b/calcite-qml/Calcite/CheckIndicator.qml
@@ -14,7 +14,6 @@
  *  limitations under the License.
  ******************************************************************************/
 import QtQuick
-import Qt5Compat.GraphicalEffects
 
 Rectangle {
     property var control;
@@ -37,12 +36,5 @@ Rectangle {
         }
         source: control.checkState === Qt.Checked ? "images/check.svg": "images/line-solid.svg"
         visible: false
-    }
-
-    ColorOverlay {
-        anchors.fill: checkmark
-        source: checkmark
-        color: Calcite.textInverse
-        visible: control.checkState !== Qt.Unchecked
     }
 }

--- a/calcite-qml/Calcite/ComboBox.qml
+++ b/calcite-qml/Calcite/ComboBox.qml
@@ -16,6 +16,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Templates as T
+import Qt5Compat.GraphicalEffects
 
 T.ComboBox {
     id: control
@@ -39,6 +40,12 @@ T.ComboBox {
         y: control.topPadding + (control.availableHeight - height) / 2
         source: "images/caret-double-vertical.svg"
         visible: false
+    }
+
+    ColorOverlay {
+        anchors.fill: indicator
+        source: indicator
+        color: Calcite.text3
     }
 
     contentItem: Text {

--- a/calcite-qml/Calcite/ComboBox.qml
+++ b/calcite-qml/Calcite/ComboBox.qml
@@ -16,7 +16,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Templates as T
-import Qt5Compat.GraphicalEffects
 
 T.ComboBox {
     id: control
@@ -39,13 +38,7 @@ T.ComboBox {
         x: control.mirrored ? control.leftPadding : control.width - width - control.rightPadding
         y: control.topPadding + (control.availableHeight - height) / 2
         source: "images/caret-double-vertical.svg"
-        visible: false
-    }
-
-    ColorOverlay {
-        anchors.fill: indicator
-        source: indicator
-        color: Calcite.text3
+        visible: true
     }
 
     contentItem: Text {

--- a/calcite-qml/Calcite/ComboBox.qml
+++ b/calcite-qml/Calcite/ComboBox.qml
@@ -16,7 +16,6 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Templates as T
-import Qt5Compat.GraphicalEffects
 
 T.ComboBox {
     id: control
@@ -40,12 +39,6 @@ T.ComboBox {
         y: control.topPadding + (control.availableHeight - height) / 2
         source: "images/caret-double-vertical.svg"
         visible: false
-    }
-
-    ColorOverlay {
-        anchors.fill: indicator
-        source: indicator
-        color: Calcite.text3
     }
 
     contentItem: Text {

--- a/calcite-qml/Calcite/ItemDelegate.qml
+++ b/calcite-qml/Calcite/ItemDelegate.qml
@@ -17,7 +17,6 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.impl
 import QtQuick.Templates as T
-import Qt5Compat.GraphicalEffects
 
 T.ItemDelegate {
     id: control
@@ -44,12 +43,6 @@ T.ItemDelegate {
 
         visible: control.highlighted
         source: "images/check.svg"
-        ColorOverlay {
-            anchors.fill: indicator
-            source: indicator
-            color: control.color
-            visible: indicator.visible
-        }
     }
     contentItem: IconLabel {
         spacing: control.spacing

--- a/calcite-qml/Calcite/ItemDelegate.qml
+++ b/calcite-qml/Calcite/ItemDelegate.qml
@@ -17,6 +17,7 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Controls.impl
 import QtQuick.Templates as T
+import Qt5Compat.GraphicalEffects
 
 T.ItemDelegate {
     id: control
@@ -43,6 +44,12 @@ T.ItemDelegate {
 
         visible: control.highlighted
         source: "images/check.svg"
+        ColorOverlay {
+            anchors.fill: indicator
+            source: indicator
+            color: control.color
+            visible: indicator.visible
+        }
     }
     contentItem: IconLabel {
         spacing: control.spacing

--- a/calcite-qml/Calcite/MenuItem.qml
+++ b/calcite-qml/Calcite/MenuItem.qml
@@ -15,6 +15,7 @@
  ******************************************************************************/
 import QtQuick
 import QtQuick.Templates as T
+import Qt5Compat.GraphicalEffects
 
 T.MenuItem {
     id: control
@@ -46,6 +47,11 @@ T.MenuItem {
 
         visible: control.checked
         source: control.checkable ? "images/check.svg" : ""
+        ColorOverlay {
+            anchors.fill: parent
+            source: parent
+            color: control.contentItem.color
+        }
     }
 
     background: Item {

--- a/calcite-qml/Calcite/MenuItem.qml
+++ b/calcite-qml/Calcite/MenuItem.qml
@@ -15,7 +15,6 @@
  ******************************************************************************/
 import QtQuick
 import QtQuick.Templates as T
-import Qt5Compat.GraphicalEffects
 
 T.MenuItem {
     id: control
@@ -47,11 +46,6 @@ T.MenuItem {
 
         visible: control.checked
         source: control.checkable ? "images/check.svg" : ""
-        ColorOverlay {
-            anchors.fill: parent
-            source: parent
-            color: control.contentItem.color
-        }
     }
 
     background: Item {

--- a/calcite-qml/Calcite/RadioDelegate.qml
+++ b/calcite-qml/Calcite/RadioDelegate.qml
@@ -62,13 +62,6 @@ T.RadioDelegate {
         sourceSize: Qt.size(24, 24)
         width: sourceSize.width
         height: sourceSize.height
-        ColorOverlay {
-            anchors.fill: indicator
-            source: indicator
-            color: control.checked
-                   || control.highlighted ? Calcite.brand : control.hovered ? Calcite.border1 : "transparent"
-            visible: indicator.visible
-        }
     }
 
     background: Rectangle {

--- a/calcite-qml/Calcite/RadioDelegate.qml
+++ b/calcite-qml/Calcite/RadioDelegate.qml
@@ -62,6 +62,13 @@ T.RadioDelegate {
         sourceSize: Qt.size(24, 24)
         width: sourceSize.width
         height: sourceSize.height
+        ColorOverlay {
+            anchors.fill: indicator
+            source: indicator
+            color: control.checked
+                   || control.highlighted ? Calcite.brand : control.hovered ? Calcite.border1 : "transparent"
+            visible: indicator.visible
+        }
     }
 
     background: Rectangle {

--- a/calcite-qml/Calcite/SpinBox.qml
+++ b/calcite-qml/Calcite/SpinBox.qml
@@ -81,12 +81,6 @@ T.SpinBox {
                 sourceSize.width: parent.width
                 sourceSize.height: parent.width
             }
-
-            ColorOverlay {
-                anchors.fill : upIndicatorImage
-                source: upIndicatorImage
-                color: up.hovered ? Calcite.text1 : Calcite.text3
-            }
         }
     }
 
@@ -115,12 +109,6 @@ T.SpinBox {
                 source: "images/chevron-left.svg"
                 sourceSize.width: parent.width
                 sourceSize.height: parent.height
-            }
-
-            ColorOverlay {
-                anchors.fill : downIndicatorImage
-                source: downIndicatorImage
-                color: down.hovered ? Calcite.text1 : Calcite.text3
             }
         }
     }

--- a/calcite-qml/Calcite/SpinBox.qml
+++ b/calcite-qml/Calcite/SpinBox.qml
@@ -15,7 +15,6 @@
  ******************************************************************************/
 import QtQuick
 import QtQuick.Templates as T
-import Qt5Compat.GraphicalEffects
 
 T.SpinBox {
     id: control
@@ -81,12 +80,6 @@ T.SpinBox {
                 sourceSize.width: parent.width
                 sourceSize.height: parent.width
             }
-
-            ColorOverlay {
-                anchors.fill : upIndicatorImage
-                source: upIndicatorImage
-                color: up.hovered ? Calcite.text1 : Calcite.text3
-            }
         }
     }
 
@@ -115,12 +108,6 @@ T.SpinBox {
                 source: "images/chevron-left.svg"
                 sourceSize.width: parent.width
                 sourceSize.height: parent.height
-            }
-
-            ColorOverlay {
-                anchors.fill : downIndicatorImage
-                source: downIndicatorImage
-                color: down.hovered ? Calcite.text1 : Calcite.text3
             }
         }
     }

--- a/calcite-qml/Calcite/SpinBox.qml
+++ b/calcite-qml/Calcite/SpinBox.qml
@@ -81,6 +81,12 @@ T.SpinBox {
                 sourceSize.width: parent.width
                 sourceSize.height: parent.width
             }
+
+            ColorOverlay {
+                anchors.fill : upIndicatorImage
+                source: upIndicatorImage
+                color: up.hovered ? Calcite.text1 : Calcite.text3
+            }
         }
     }
 
@@ -109,6 +115,12 @@ T.SpinBox {
                 source: "images/chevron-left.svg"
                 sourceSize.width: parent.width
                 sourceSize.height: parent.height
+            }
+
+            ColorOverlay {
+                anchors.fill : downIndicatorImage
+                source: downIndicatorImage
+                color: down.hovered ? Calcite.text1 : Calcite.text3
             }
         }
     }

--- a/calcite-qml/demo/calcite_test.pro
+++ b/calcite-qml/demo/calcite_test.pro
@@ -29,17 +29,17 @@ include($$PWD/arcgisruntime.pri)
 TEMPLATE = app
 TARGET = calcite_test
 
-equals(QT_MAJOR_VERSION, 5) {
-    lessThan(QT_MINOR_VERSION, 15) {
-        error("$$TARGET requires Qt 5.15.2")
-    }
-        equals(QT_MINOR_VERSION, 15) : lessThan(QT_PATCH_VERSION, 2) {
-                error("$$TARGET requires Qt 5.15.2")
-        }
+lessThan(QT_MAJOR_VERSION, 6) {
+    error("This version of the ArcGIS Runtime SDK for Qt requires Qt 6.2.4")
 }
 
 equals(QT_MAJOR_VERSION, 6) {
-  error("This version of the ArcGIS Runtime SDK for Qt is incompatible with Qt 6")
+    lessThan(QT_MINOR_VERSION, 2) {
+        error("This version of the ArcGIS Runtime SDK for Qt requires Qt 6.2.4")
+    }
+  equals(QT_MINOR_VERSION, 2) : lessThan(QT_PATCH_VERSION, 4) {
+    error("This version of the ArcGIS Runtime SDK for Qt requires Qt 6.2.4")
+  }
 }
 
 #-------------------------------------------------------------------------------

--- a/calcite-qml/demo/main.cpp
+++ b/calcite-qml/demo/main.cpp
@@ -59,11 +59,6 @@ main(int argc, char* argv[])
   // QCoreApplication::instance()->setProperty("Esri.ArcGISRuntime.license",
   // "licenseString");
 
-  // This is how we make the style visible to our application!
-  // We can now apply the style via the `qtquickcontrol2.conf` file.
-  // See `README.md` for details.
-  QQuickStyle::addStylePath("qrc:///esri.com/imports/");
-
   // Intialize application window
   QQmlApplicationEngine appEngine;
   appEngine.addImportPath("qrc:///esri.com/imports/");

--- a/uitools/examples/cpp_quick/cpp_quick.pro
+++ b/uitools/examples/cpp_quick/cpp_quick.pro
@@ -26,15 +26,6 @@ QML_IMPORT_MAJOR_VERSION = 1
 
 TARGET = cpp_quick
 
-equals(QT_MAJOR_VERSION, 5) {
-    lessThan(QT_MINOR_VERSION, 15) {
-        error("$$TARGET requires Qt 5.15.2")
-    }
-        equals(QT_MINOR_VERSION, 15) : lessThan(QT_PATCH_VERSION, 2) {
-                error("$$TARGET requires Qt 5.15.2")
-        }
-}
-
 lessThan(QT_MAJOR_VERSION, 6) {
     error("This version of the ArcGIS Runtime SDK for Qt requires Qt 6.2.4")
 }

--- a/uitools/examples/qml_quick/qml_quick.pro
+++ b/uitools/examples/qml_quick/qml_quick.pro
@@ -31,15 +31,6 @@ include($$PWD/../../toolkitqml.pri)
 TEMPLATE = app
 TARGET = qml_quick
 
-equals(QT_MAJOR_VERSION, 5) {
-    lessThan(QT_MINOR_VERSION, 15) {
-        error("$$TARGET requires Qt 5.15.2")
-    }
-        equals(QT_MINOR_VERSION, 15) : lessThan(QT_PATCH_VERSION, 2) {
-                error("$$TARGET requires Qt 5.15.2")
-        }
-}
-
 lessThan(QT_MAJOR_VERSION, 6) {
     error("This version of the ArcGIS Runtime SDK for Qt requires Qt 6.2.4")
 }

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
@@ -18,7 +18,6 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import QtQml.Models
-import Qt5Compat.GraphicalEffects
 
 /*!
   \qmltype FloorFilter
@@ -321,7 +320,7 @@ Control {
                         id: searchImg
                         sourceSize.width: 32
                         sourceSize.height: 32
-                        visible: false
+                        visible: true
                         source: "images/search.svg"
                         width: height
                         anchors {
@@ -330,11 +329,6 @@ Control {
                             bottom: parent.bottom
                             margins: 4
                         }
-                    }
-                    ColorOverlay {
-                        anchors.fill: searchImg
-                        source: searchImg
-                        color: noResultsFoundLabel.color
                     }
                 }
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
@@ -331,11 +331,6 @@ Control {
                             margins: 4
                         }
                     }
-                    ColorOverlay {
-                        anchors.fill: searchImg
-                        source: searchImg
-                        color: noResultsFoundLabel.color
-                    }
                 }
 
                 Label {

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/FloorFilter.qml
@@ -331,6 +331,11 @@ Control {
                             margins: 4
                         }
                     }
+                    ColorOverlay {
+                        anchors.fill: searchImg
+                        source: searchImg
+                        color: noResultsFoundLabel.color
+                    }
                 }
 
                 Label {

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/SearchView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/SearchView.qml
@@ -288,6 +288,12 @@ Pane {
                         source: markerImageUrl
                         sourceSize.height: 32
                         visible: true
+                        ColorOverlay {
+                            anchors.fill: sourceImage
+                            source: sourceImage
+                            color: textLabel.color
+                            visible: searchView.state !== "searchCommitted"
+                        }
                     }
                     Label {
                         id: textLabel

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/SearchView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/SearchView.qml
@@ -19,7 +19,6 @@ import Esri.ArcGISRuntime.Toolkit.Controller
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import Qt5Compat.GraphicalEffects
 
 /*!
     \qmltype SearchView
@@ -287,13 +286,7 @@ Pane {
                         Layout.rowSpan: 2
                         source: markerImageUrl
                         sourceSize.height: 32
-                        visible: true
-                        ColorOverlay {
-                            anchors.fill: sourceImage
-                            source: sourceImage
-                            color: textLabel.color
-                            visible: searchView.state !== "searchCommitted"
-                        }
+                        visible: searchView.state !== "searchCommitted"
                     }
                     Label {
                         id: textLabel

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/SearchView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/SearchView.qml
@@ -288,12 +288,6 @@ Pane {
                         source: markerImageUrl
                         sourceSize.height: 32
                         visible: true
-                        ColorOverlay {
-                            anchors.fill: sourceImage
-                            source: sourceImage
-                            color: textLabel.color
-                            visible: searchView.state !== "searchCommitted"
-                        }
                     }
                     Label {
                         id: textLabel


### PR DESCRIPTION
Removing `ColorOverlay` as it is not supported out of the box in Qt 6. These changes are minimal, aesthetic, and sub-perceptual - although it's sad to see them go, we can live without them.

Tested both Cpp and Qml example apps. 

@ldanzinger please review. 