### PR TITLE
Fix misleading indentation

### DIFF
--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/Internal/GenericTableProxyModel.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/Internal/GenericTableProxyModel.cpp
@@ -289,8 +289,8 @@ QVariant GenericTableProxyModel::headerData(int section, Qt::Orientation orienta
   if (role != Qt::DisplayRole)
     return QVariant();
 
-if (Qt::Orientation::Vertical == orientation)
-  return section + 1;
+  if (Qt::Orientation::Vertical == orientation)
+    return section + 1;
 
   const auto roles = m_sourceModel ? m_sourceModel->roleNames() : QHash<int, QByteArray>();
   auto it = roles.find(section + Qt::UserRole + 1);


### PR DESCRIPTION
I get a compiler warning for this every time and I'd like to fix this.

```
~Applications/arcgis-runtime-samples-qt/arcgis-runtime-toolkit-qt/uitools/cpp/Esri/ArcGISRuntime/Toolkit/Internal/GenericTableProxyModel.cpp:295: warning: misleading indentation; statement is not part of the previous 'if' [-Wmisleading-indentation]
../../arcgis-runtime-toolkit-qt/uitools/cpp/Esri/ArcGISRuntime/Toolkit/Internal/GenericTableProxyModel.cpp:295:3: warning: misleading indentation; statement is not part of the previous 'if' [-Wmisleading-indentation]
  const auto roles = m_sourceModel ? m_sourceModel->roleNames() : QHash<int, QByteArray>();
  ^
../../arcgis-runtime-toolkit-qt/uitools/cpp/Esri/ArcGISRuntime/Toolkit/Internal/GenericTableProxyModel.cpp:292:1: note: previous statement is here
if (Qt::Orientation::Vertical == orientation)
^
```