### PR TITLE
fix doc warnings

### DIFF
--- a/augmentedreality/Common/source/ArcGISArViewInterface.cpp
+++ b/augmentedreality/Common/source/ArcGISArViewInterface.cpp
@@ -418,7 +418,7 @@ std::array<double, 7> ArcGISArViewInterface::hitTestInternal(int x, int y) const
   \endlist
 
   \code
-  ArSession* arSession = arcGISArView->getAR<ArSession>();
+  ArSession* arSession = arcGISArView->arRawPtr<ArSession>(); // ARSession on iOS and ArSession on Android
   if (arSession)
   {
     // use AR session

--- a/augmentedreality/Common/source/ArcGISArViewInterface.cpp
+++ b/augmentedreality/Common/source/ArcGISArViewInterface.cpp
@@ -22,12 +22,12 @@
 #include <QScreen>
 #include "ArWrapper.h"
 
-
-using namespace Esri::ArcGISRuntime::Toolkit;
 using namespace Esri::ArcGISRuntime::Toolkit::Internal;
 
+namespace Esri::ArcGISRuntime::Toolkit {
+
 /*!
-  \class ArcGISArViewInterface
+  \class Esri::ArcGISRuntime::Toolkit::ArcGISArViewInterface
   \ingroup ArcGISQtToolkit
   \ingroup ArcGISQtToolkitAR
   \ingroup ArcGISQtToolkitARCppApi
@@ -37,8 +37,8 @@ using namespace Esri::ArcGISRuntime::Toolkit::Internal;
   \brief Base class to impement AR scene view.
 
   This class provides the AR features without using the C++ or QML APIs of the ArcGIS Runtime SDK for Qt.
-  It is used as a base class to create two API-dependent classes: \l ArcGISArSceneView which uses the C++ API and
-  \l QmlArcGISArSceneView which uses the QML API.
+  It is used as a base class to create two API-dependent classes: \l [CPP] ArcGISArView which uses the C++ API and
+  \l [QML] ArcGISArView which uses the QML API.
  */
 
 /*!
@@ -110,7 +110,7 @@ bool ArcGISArViewInterface::tracking() const
 }
 
 /*!
-  \brief Starts or stops the AR scene view tracking.
+  \brief Sets \a tracking to starts or stops the AR scene view tracking.
  */
 void ArcGISArViewInterface::setTracking(bool tracking)
 {
@@ -129,7 +129,7 @@ bool ArcGISArViewInterface::renderVideoFeed() const
 }
 
 /*!
-  \brief Sets to \c true when the scene view renders the camera frames in the background.
+  \brief Sets \a renderVideoFeed to \c true when the scene view renders the camera frames in the background.
  */
 void ArcGISArViewInterface::setRenderVideoFeed(bool renderVideoFeed)
 {
@@ -153,7 +153,7 @@ double ArcGISArViewInterface::translationFactor() const
 }
 
 /*!
-  \brief The translation factor used to support a table top AR experience.
+  \brief The \a translationFactor used to support a table top AR experience.
 
   All the translation of the device are multiplied by this factor, to have translations in
   the scene view adapted to the scene zooming.
@@ -397,24 +397,28 @@ std::array<double, 7> ArcGISArViewInterface::hitTestInternal(int x, int y) const
 
   \section1 On iOS
 
+  On iOS, the template argument must be one of the types from the following list:
+
   \list
-  \li \a ARSession - The current AR session object. https://developer.apple.com/documentation/arkit/arsession?language=objc
-  \li \a ARConfiguration - The AR configuration object used to run the AR session.
+  \li ARSession - The current AR session object. https://developer.apple.com/documentation/arkit/arsession?language=objc
+  \li ARConfiguration - The AR configuration object used to run the AR session.
   https://developer.apple.com/documentation/arkit/arconfiguration?language=objc
-  \li \a NSObject<ARSessionDelegate> - The session delegate which received the updates.
+  \li NSObject<ARSessionDelegate> - The session delegate which received the updates.
   https://developer.apple.com/documentation/arkit/arsessiondelegate?language=objc
   \endlist
 
   \section1 On Android
 
+  On Android, the template argument must be one of the types from the following list:
+
   \list
-  \li \a ArSession - The current AR session object. https://developers.google.com/ar/reference/c/group/session
-  \li \a ArFrame - The last received AR frame object. https://developers.google.com/ar/reference/c/group/frame
-  \li \a ArCamera - The last received AR camera object. https://developers.google.com/ar/reference/c/group/camera
+  \li ArSession - The current AR session object. https://developers.google.com/ar/reference/c/group/session
+  \li ArFrame - The last received AR frame object. https://developers.google.com/ar/reference/c/group/frame
+  \li ArCamera - The last received AR camera object. https://developers.google.com/ar/reference/c/group/camera
   \endlist
 
   \code
-  ARSession* arSession = arcGISArView->getAR<ARSession>();
+  ArSession* arSession = arcGISArView->getAR<ArSession>();
   if (arSession)
   {
     // use AR session
@@ -443,3 +447,5 @@ ArRawPtr* ArcGISArViewInterface::arRawPtr() const
   \fn void ArcGISArViewInterface::trackingChanged()
   \brief Signal emitted when the \l tracking property changes.
  */
+
+} // Esri::ArcGISRuntime::Toolkit namespace

--- a/augmentedreality/CppApi/source/ArcGISArView.cpp
+++ b/augmentedreality/CppApi/source/ArcGISArView.cpp
@@ -25,11 +25,12 @@
 #include <QScreen>
 
 using namespace Esri::ArcGISRuntime;
-using namespace Esri::ArcGISRuntime::Toolkit;
 using namespace Esri::ArcGISRuntime::Toolkit::Internal;
 
+namespace Esri::ArcGISRuntime::Toolkit {
+
 /*!
-  \class ArcGISArView
+  \class Esri::ArcGISRuntime::Toolkit::ArcGISArView
   \ingroup ArcGISQtToolkit
   \ingroup ArcGISQtToolkitAR
   \ingroup ArcGISQtToolkitARCppApi
@@ -412,3 +413,4 @@ void ArcGISArView::updateTmccOriginCamera() const
   \brief Signal emitted when the \l sceneView property changes.
  */
 
+} // Esri::ArcGISRuntime::Toolkit namespace

--- a/augmentedreality/QmlApi/source/QmlArcGISArView.cpp
+++ b/augmentedreality/QmlApi/source/QmlArcGISArView.cpp
@@ -16,17 +16,17 @@
 
 #include "QmlArcGISArView.h"
 
-using namespace Esri::ArcGISRuntime::Toolkit;
+namespace Esri::ArcGISRuntime::Toolkit {
 
 /*!
   \qmltype ArcGISArView
-  \instantiates QmlArcGISArView
+  \instantiates Esri::ArcGISRuntime::Toolkit::QmlArcGISArView
   \inherits ArcGISArViewInterface
   \ingroup ArcGISQtToolkitAR
   \ingroup ArcGISQtToolkitARQmlApi
   \ingroup ArcGISQtToolkit
   \ingroup ArcGISQtToolkitQmlApi
-  \inmodule ArcGISQtToolkit
+  \inqmlmodule ArcGISQtToolkit
   \since Esri::ArcGISArToolkit  100.6
   \brief A scene view for displaying ARKit/ARCore features on mobile devices
    using the QML API.
@@ -280,3 +280,5 @@ bool QmlArcGISArView::assertClassName(QObject* object, const QString& className)
   \fn void QmlArcGISArView::sceneViewChanged();
   \brief Signal emitted when the \l sceneView property changes.
  */
+
+} // Esri::ArcGISRuntime::Toolkit namespace

--- a/tests/uitools/qml_quick/shared/utils.cpp
+++ b/tests/uitools/qml_quick/shared/utils.cpp
@@ -23,8 +23,6 @@ QString Utils::urlFileName(const QString& urlName)
 /*!
  \internal
  \brief Creates a Singleton Instance that can be accesses without instantiating the class.
- \param engine
- \param scriptEngine 
  */
 QObject* Utils::createSingletonInstance(QQmlEngine* engine, QJSEngine* scriptEngine)
 {

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/BookmarksViewController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/BookmarksViewController.cpp
@@ -245,7 +245,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
   }
 
   /*!
-  \brief Updates the \c GeoView camera to point to the current bookmark's
+  \brief Updates the \c GeoView camera to point to the current \a bookmark's
   location on the map.
  */
   void BookmarksViewController::zoomToBookmarkExtent(BookmarkListItem* bookmark)
@@ -271,7 +271,7 @@ namespace Esri::ArcGISRuntime::Toolkit {
   /*!
   \property Esri::ArcGISRuntime::Toolkit::BookmarksViewController::geoView
   \brief The geoView the controller is utilizing for interactions.
-  \sa Esri::ArcGISRuntime::Toolkit::BookmarksViewController::geoView() const
+  \sa Esri::ArcGISRuntime::Toolkit::BookmarksViewController::geoView
  */
 
 } // Esri::ArcGISRuntime::Toolkit

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/CoordinateOptionDefaults.qdoc
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/CoordinateOptionDefaults.qdoc
@@ -1,5 +1,6 @@
 /*!
 * \headerfile Esri/ArcGISRuntime/Toolkit/CoordinateOptionDefaults
+* \inmodule ArcGISRuntimeToolkit
 * This file contains several function to instantiate several kinds of common
 * CoordinateConversionOption objects used by a CoordinateConversionController.
 * \sa Esri::ArcGISRuntime::Toolkit::CoordinateConversionOption

--- a/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterController.cpp
+++ b/uitools/cpp/Esri/ArcGISRuntime/Toolkit/FloorFilterController.cpp
@@ -915,17 +915,17 @@ namespace Esri::ArcGISRuntime::Toolkit {
  */
 
   /*!
-  \fn void Esri::ArcGISRuntime::Toolkit::FloorFilterController::selectedSiteIdChanged(QString oldId, QString newId)
+  \fn void Esri::ArcGISRuntime::Toolkit::FloorFilterController::selectedSiteIdChanged(const QString& oldId, const QString& newId)
   \brief Emitted when the selectedSiteId has changed from \a oldId to \a newId.
  */
 
   /*!
-  \fn void Esri::ArcGISRuntime::Toolkit::FloorFilterController::selectedFacilityIdChanged(QString oldId, QString newId)
+  \fn void Esri::ArcGISRuntime::Toolkit::FloorFilterController::selectedFacilityIdChanged(const QString& oldId, const QString& newId)
   \brief Emitted when the selectedFacilityId has changed from \a oldId to \a newId.
  */
 
   /*!
-  \fn void Esri::ArcGISRuntime::Toolkit::FloorFilterController::selectedLevelIdChanged(QString oldId, QString newId)
+  \fn void Esri::ArcGISRuntime::Toolkit::FloorFilterController::selectedLevelIdChanged(const QString& oldId, const QString& newId)
   \brief Emitted when the selectedLevelId has changed from \a oldId to \a newId.
  */
 

--- a/uitools/examples/qml_quick/src/demos/BookmarksViewDemoForm.qml
+++ b/uitools/examples/qml_quick/src/demos/BookmarksViewDemoForm.qml
@@ -26,10 +26,11 @@ DemoPage {
 
             Map {
                 PortalItem {
-                   itemId: "16f1b8ba37b44dc3884afc8d5f454dd2"
+                    itemId: "16f1b8ba37b44dc3884afc8d5f454dd2"
                 }
             }
 
+            //! [Set up Bookmark QML]
             BookmarksView {
                 id: bookmarksView
                 geoView: view
@@ -39,6 +40,7 @@ DemoPage {
                     margins: 10
                 }
             }
+            //! [Set up Bookmark QML]
         }
     }
 }

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/CoordinateConversionController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/CoordinateConversionController.qml
@@ -71,7 +71,7 @@ QtObject {
      */
     property list<CoordinateConversionResult> results
 
-    /*! \brief Emitted when the currentPoint has changed. */
+    /*! \brief Emitted when the current \a point has changed. */
     signal currentPointChanged(Point point)
 
     /*!

--- a/uitools/register/Esri/ArcGISRuntime/Toolkit/register.cpp
+++ b/uitools/register/Esri/ArcGISRuntime/Toolkit/register.cpp
@@ -17,6 +17,7 @@
 
 /*!
   \headerfile Esri/ArcGISRuntime/Toolkit/register
+  \inmodule ArcGISRuntimeToolkit
 
   This file contains the registration function required to register the toolkit
   with the `QQmlEngine`.
@@ -26,9 +27,9 @@
 */
 
 /*!
-  \fn void Esri::ArcGISRuntime::Toolkit::registerComponents(QmlEngine& engine)
+  \fn void Esri::ArcGISRuntime::Toolkit::registerComponents(QQmlEngine& engine)
   \relates Esri/ArcGISRuntime/Toolkit/register
-  \brief This registration function must be called after the QmlEngine has been
+  \brief This registration function must be called after the QML \a engine has been
   declared, but before it is run. This sets up resources and component registration
   with the `QQmlEngine` and the toolkit.
  */

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificatePasswordDialog.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificatePasswordDialog.cpp
@@ -19,12 +19,13 @@
 
 namespace Esri::ArcGISRuntime::Toolkit {
 
-  /*!
-  \brief Constructor.
-  \list
-    \li \a parent Parent widget.
-  \endlist
+/*!
+   \internal
+   \class Esri::ArcGISRuntime::Toolkit::ClientCertificatePasswordDialog
+   \inmodule EsriArcGISRuntimeToolkit
+   \brief This is an implementation of dialog to request password for client certificate.
  */
+
   ClientCertificatePasswordDialog::ClientCertificatePasswordDialog(QUrl certificateFile, AuthenticationController* controller, QWidget* parent) :
     QDialog(parent),
     m_certificateFile(std::move(certificateFile)),
@@ -53,6 +54,9 @@ namespace Esri::ArcGISRuntime::Toolkit {
             });
   }
 
+  /*!
+    \brief Destructor
+   */
   ClientCertificatePasswordDialog::~ClientCertificatePasswordDialog()
   {
     delete m_ui;

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificateView.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/ClientCertificateView.cpp
@@ -24,12 +24,13 @@
 
 namespace Esri::ArcGISRuntime::Toolkit {
 
-  /*!
-  \brief Constructor.
-  \list
-    \li \a parent Parent widget.
-  \endlist
+/*!
+   \internal
+   \class Esri::ArcGISRuntime::Toolkit::ClientCertificateView
+   \inmodule EsriArcGISRuntimeToolkit
+   \brief This is an implementation of dialog to select a client certificate.
  */
+
   ClientCertificateView::ClientCertificateView(AuthenticationController* controller, QWidget* parent) :
     QWidget(parent),
     m_controller(controller),

--- a/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/SslHandshakeView.cpp
+++ b/uitools/widgets/Esri/ArcGISRuntime/Toolkit/Internal/SslHandshakeView.cpp
@@ -19,12 +19,13 @@
 
 namespace Esri::ArcGISRuntime::Toolkit {
 
-  /*!
-  \brief Constructor.
-  \list
-    \li \a parent Parent widget.
-  \endlist
+/*!
+   \internal
+   \class Esri::ArcGISRuntime::Toolkit::SslHandshakeView
+   \inmodule EsriArcGISRuntimeToolkit
+   \brief This is an implementation of dialog for SSL handshake.
  */
+
   SslHandshakeView::SslHandshakeView(AuthenticationController* controller, QWidget* parent) :
     QWidget(parent),
     m_controller(controller),


### PR DESCRIPTION
Fix some doc warnings.

There are still 2 "known" warnings:

```
toolkit/augmentedreality/QmlApi/source/QmlArcGISArView.cpp:260: (qdoc) warning: 
    QML property documented multiple times: 'double ArcGISArView::clippingDistance'
```
This function is documented in base class and in QML class. Maybe it's possible to merge these documentations?

```
toolkit/uitools/import/Esri/ArcGISRuntime/Toolkit/CurrentVersion.qml:19: 
    (qdoc) warning: Overrides a previous doc
toolkit/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/CurrentVersion.qml:19: 
    (qdoc) warning: (The previous doc is here)
```
I don't know why this class is defined 2 times. Maybe it's not necessary to keep both?