### PR TITLE
properly match rowInserted parameters

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/SearchViewController.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/Controller/SearchViewController.qml
@@ -296,7 +296,7 @@ QtObject {
         property Point queryCenter: null
 
         property ListModel sources: ListModel {
-            onRowsInserted: (first, last) =>{
+            onRowsInserted: (parent, first, last) =>{
                 for (let i = first; i <= last; ++i) {
                     const source = sources.get(i).modelData;
                     if (source) {


### PR DESCRIPTION
Search was broken in the qml_quick example app, due to this onRowInserted handler not having the proper list of named parameters.