### PR TITLE
Mfeigl/changing utility network trace button order

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/UtilityNetworkTrace.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/UtilityNetworkTrace.qml
@@ -221,6 +221,14 @@ Pane {
                 RowLayout {
                     Layout.margins: 0
                     visible: true
+                    Button {
+                        id: selectStartingPointButton
+                        text: controller.isAddingStartingPointEnabled ? "Cancel" : "Add Starting Point"
+                        Layout.alignment: Qt.AlignRight
+                        Layout.maximumWidth: Layout.maximumHeight
+                        padding: 0
+                        onClicked: controller.isAddingStartingPointEnabled = !controller.isAddingStartingPointEnabled
+                    }
 
                     Button {
                         id: removeAllButton
@@ -232,14 +240,6 @@ Pane {
                         visible: startPointList.count > 0
                     }
 
-                    Button {
-                        id: selectStartingPointButton
-                        text: controller.isAddingStartingPointEnabled ? "Cancel" : "Add Starting Point"
-                        Layout.alignment: Qt.AlignRight
-                        Layout.maximumWidth: Layout.maximumHeight
-                        padding: 0
-                        onClicked: controller.isAddingStartingPointEnabled = !controller.isAddingStartingPointEnabled
-                    }
                 }
 
                 ColumnLayout {

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/UtilityNetworkTrace.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/UtilityNetworkTrace.qml
@@ -221,6 +221,7 @@ Pane {
                 RowLayout {
                     Layout.margins: 0
                     visible: true
+
                     Button {
                         id: selectStartingPointButton
                         text: controller.isAddingStartingPointEnabled ? "Cancel" : "Add Starting Point"
@@ -239,7 +240,6 @@ Pane {
                         onClicked: controller.removeAllStartingPoints()
                         visible: startPointList.count > 0
                     }
-
                 }
 
                 ColumnLayout {


### PR DESCRIPTION
Changed the Utility Network Trace tool's button order. One (which is now on the left) is permanently displayed, while the other (now on the right) is conditionally displayed, so it made more sense not to have the permanent button jumping based on the condition of the other button.