### PR TITLE
The AuthenticationController is provided to these from the Authentica…

### DIFF
--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/ClientCertificateView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/ClientCertificateView.qml
@@ -22,7 +22,7 @@ import Qt.labs.platform as P
 
 Dialog {
     id: clientCertificateView
-    property AuthenticationController controller: AuthenticationController {}
+    property AuthenticationController controller: null
 
     title: qsTr("Client certificate requested")
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/OAuth2View.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/OAuth2View.qml
@@ -24,7 +24,7 @@ import QtQuick.Window
 Dialog {
     id: oAuthView
 
-    property AuthenticationController controller: AuthenticationController {}
+    property AuthenticationController controller: null
 
     title: webView.title
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/SslHandshakeView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/SslHandshakeView.qml
@@ -22,7 +22,7 @@ import QtQuick.Layouts
 
 Dialog {
 
-    property AuthenticationController controller: AuthenticationController {}
+    property AuthenticationController controller: null
 
     title: qsTr("Untrusted Host")
 

--- a/uitools/import/Esri/ArcGISRuntime/Toolkit/UserCredentialsView.qml
+++ b/uitools/import/Esri/ArcGISRuntime/Toolkit/UserCredentialsView.qml
@@ -23,7 +23,7 @@ import QtQuick.Layouts
 Dialog {
     id: userCredentialsView
 
-    property AuthenticationController controller: AuthenticationController {}
+    property AuthenticationController controller: null
 
     title: qsTr("Authentication required")
 


### PR DESCRIPTION
…tionView.

**I will not merge this regardless of approvals until the 200.0 release is finalized.**

A problem discovered during certification is that each authentication window has its own AuthenticationController. In prior releases this wasn't a problem, but we recently added logic [here](https://github.com/Esri/arcgis-runtime-toolkit-qt/commit/0ac50bb4dace8d341f44b9d45a31c0e4282f8ce2) to cancel challenges when the AuthenticationController destructs.

This means there are multiple controllers alive at the same time, and they can cancel each other's challenges. This was seen in this test sequence:
1. Untrusted host (`SslHandshakeView.qml`)
2. Accept risk and continue
3. User credentials challenge presented to the user

In step 2, once `SslHandshakeView.qml` was dismissed, its AuthenticationController would destruct and cancel the challenge from `UserCredentialsView.qml` pending in step 3.

Since the workflow we promote is to use the AuthenicationView, there is no need for these dialogs to create their own `AuthenticationController`. The AuthenticationView provides it as needed, and that way there is a single `AuthenticationController` at a time.

These are the tests I have done so far:
 * The problem https://github.com/Esri/arcgis-runtime-toolkit-qt/commit/0ac50bb4dace8d341f44b9d45a31c0e4282f8ce2 fixed is still fixed.
 * The test sequence mentioned above is now fixed.

I will do additional testing.